### PR TITLE
🔀 :: (#44) - publishing student management

### DIFF
--- a/app/src/main/java/com/goms/goms_android_v2/navigation/GomsNavHost.kt
+++ b/app/src/main/java/com/goms/goms_android_v2/navigation/GomsNavHost.kt
@@ -15,7 +15,9 @@ import com.goms.main.navigation.mainScreen
 import com.goms.main.navigation.navigateToLateList
 import com.goms.main.navigation.navigateToMain
 import com.goms.main.navigation.navigateToOutingStatus
+import com.goms.main.navigation.navigateToStudentManagement
 import com.goms.main.navigation.outingStatusScreen
+import com.goms.main.navigation.studentManagementScreen
 import com.goms.sign_up.navigation.navigateToNumber
 import com.goms.sign_up.navigation.navigateToPassword
 import com.goms.sign_up.navigation.navigateToSignUp
@@ -63,13 +65,18 @@ fun GomsNavHost(
         mainScreen(
             viewModelStoreOwner = mainViewModelStoreOwner,
             onOutingStatusClick = navController::navigateToOutingStatus,
-            onLateListClick = navController::navigateToLateList
+            onLateListClick = navController::navigateToLateList,
+            onStudentManagementClick = navController::navigateToStudentManagement
         )
         outingStatusScreen(
             viewModelStoreOwner = mainViewModelStoreOwner,
             onBackClick = navController::popBackStack
         )
         lateListScreen(
+            viewModelStoreOwner = mainViewModelStoreOwner,
+            onBackClick = navController::popBackStack
+        )
+        studentManagementScreen(
             viewModelStoreOwner = mainViewModelStoreOwner,
             onBackClick = navController::popBackStack
         )

--- a/core/design-system/src/main/java/com/goms/design_system/component/bottomsheet/MultipleSelectorBottomSheet.kt
+++ b/core/design-system/src/main/java/com/goms/design_system/component/bottomsheet/MultipleSelectorBottomSheet.kt
@@ -1,0 +1,141 @@
+package com.goms.design_system.component.bottomsheet
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.goms.design_system.component.button.AdminBottomSheetButton
+import com.goms.design_system.theme.GomsTheme
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MultipleSelectorBottomSheet(
+    modifier: Modifier,
+    title: String,
+    subTitle1: String,
+    list1: List<String>,
+    selected1: String,
+    itemChange1: (String) -> Unit,
+    subTitle2: String,
+    list2: List<String>,
+    selected2: String,
+    itemChange2: (String) -> Unit,
+    subTitle3: String,
+    list3: List<String>,
+    selected3: String,
+    itemChange3: (String) -> Unit,
+    closeSheet: () -> Unit
+) {
+    var componentWidth by remember { mutableStateOf( 0.dp ) }
+    val density = LocalDensity.current
+
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    GomsTheme { colors, typography ->
+        ModalBottomSheet(
+            onDismissRequest = { closeSheet() },
+            sheetState = sheetState,
+            shape = RoundedCornerShape(topStart = 12.dp, topEnd = 12.dp),
+            containerColor = colors.G1
+        ) {
+            Column(
+                modifier = modifier
+                    .fillMaxWidth()
+                    .padding(start = 20.dp, end = 20.dp, bottom = 16.dp)
+                    .onGloballyPositioned {
+                        componentWidth = with(density) {
+                            it.size.width.toDp()
+                        }
+                    },
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                BottomSheetHeader(
+                    modifier = Modifier,
+                    title = title,
+                    closeSheet = closeSheet
+                )
+                Text(
+                    text = subTitle1,
+                    style = typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    color = colors.WHITE
+                )
+                LazyRow(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    items(list1.size) {
+                        AdminBottomSheetButton(
+                            modifier = Modifier.widthIn((componentWidth - 16.dp * list1.lastIndex) / list1.size),
+                            text = list1[it],
+                            selected = selected1 == list1[it]
+                        ) {
+                            itemChange1(list1[it])
+                        }
+                    }
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = subTitle2,
+                    style = typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    color = colors.WHITE
+                )
+                LazyRow(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    items(list2.size) {
+                        AdminBottomSheetButton(
+                            modifier = Modifier.widthIn((componentWidth - 16.dp * list2.lastIndex) / list2.size),
+                            text = list2[it],
+                            selected = selected2 == list2[it]
+                        ) {
+                            itemChange2(list2[it])
+                        }
+                    }
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = subTitle3,
+                    style = typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    color = colors.WHITE
+                )
+                LazyRow(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    items(list3.size) {
+                        AdminBottomSheetButton(
+                            modifier = Modifier.widthIn((componentWidth - 16.dp * list3.lastIndex) / list3.size),
+                            text = list3[it],
+                            selected = selected3 == list3[it]
+                        ) {
+                            itemChange3(list3[it])
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/core/design-system/src/main/java/com/goms/design_system/component/bottomsheet/SelectorBottomSheet.kt
+++ b/core/design-system/src/main/java/com/goms/design_system/component/bottomsheet/SelectorBottomSheet.kt
@@ -1,15 +1,9 @@
 package com.goms.design_system.component.bottomsheet
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.IntrinsicSize
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -22,15 +16,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.goms.design_system.component.button.AdminBottomSheetButton
 import com.goms.design_system.component.button.BottomSheetButton
-import com.goms.design_system.component.modifier.gomsClickable
-import com.goms.design_system.icon.CloseIcon
 import com.goms.design_system.theme.GomsTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -76,6 +68,70 @@ fun SelectorBottomSheet(
                 ) {
                     items(list.size) {
                         BottomSheetButton(
+                            modifier = Modifier.widthIn((componentWidth - 16.dp * list.lastIndex) / list.size),
+                            text = list[it],
+                            selected = selected == list[it]
+                        ) {
+                            itemChange(list[it])
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AdminSelectorBottomSheet(
+    modifier: Modifier,
+    title: String,
+    subTitle: String,
+    list: List<String>,
+    selected: String,
+    itemChange: (String) -> Unit,
+    closeSheet: () -> Unit
+) {
+    var componentWidth by remember { mutableStateOf( 0.dp ) }
+    val density = LocalDensity.current
+
+    val sheetState = rememberModalBottomSheetState()
+
+    GomsTheme { colors, typography ->
+        ModalBottomSheet(
+            onDismissRequest = { closeSheet() },
+            sheetState = sheetState,
+            shape = RoundedCornerShape(topStart = 12.dp, topEnd = 12.dp),
+            containerColor = colors.G1
+        ) {
+            Column(
+                modifier = modifier
+                    .fillMaxWidth()
+                    .padding(start = 20.dp, end = 20.dp, bottom = 16.dp)
+                    .onGloballyPositioned {
+                        componentWidth = with(density) {
+                            it.size.width.toDp()
+                        }
+                    },
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                BottomSheetHeader(
+                    modifier = Modifier,
+                    title = title,
+                    closeSheet = closeSheet
+                )
+                Text(
+                    text = subTitle,
+                    style = typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    color = colors.WHITE
+                )
+                LazyRow(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    items(list.size) {
+                        AdminBottomSheetButton(
                             modifier = Modifier.widthIn((componentWidth - 16.dp * list.lastIndex) / list.size),
                             text = list[it],
                             selected = selected == list[it]

--- a/core/design-system/src/main/java/com/goms/design_system/component/button/GomsButton.kt
+++ b/core/design-system/src/main/java/com/goms/design_system/component/button/GomsButton.kt
@@ -125,6 +125,37 @@ fun BottomSheetButton(
 }
 
 @Composable
+fun AdminBottomSheetButton(
+    modifier: Modifier = Modifier,
+    text: String,
+    selected: Boolean,
+    onClick: () -> Unit
+) {
+    GomsTheme { colors, typography ->
+        Box(
+            modifier = modifier
+                .height(56.dp)
+                .clip(RoundedCornerShape(12.dp))
+                .background(if (selected) colors.A7.copy(0.25f) else colors.G1)
+                .border(
+                    width = 1.dp,
+                    color = if (selected) Color.Transparent else colors.WHITE.copy(0.15f),
+                    shape = RoundedCornerShape(12.dp)
+                )
+                .gomsClickable { onClick() }
+        ) {
+            Text(
+                modifier = Modifier.align(Alignment.Center),
+                text = text,
+                style = typography.buttonMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = if (selected) colors.A7 else colors.G7
+            )
+        }
+    }
+}
+
+@Composable
 @Preview(showBackground = true)
 fun GomsButtonPreview() {
     Column {
@@ -156,6 +187,11 @@ fun GomsButtonPreview() {
             modifier = Modifier.fillMaxWidth(),
             text = "버튼",
             selected = false,
+        ) {}
+        AdminBottomSheetButton(
+            modifier = Modifier.fillMaxWidth(),
+            text = "버튼",
+            selected = true,
         ) {}
     }
 }

--- a/core/design-system/src/main/java/com/goms/design_system/icon/GomsIcon.kt
+++ b/core/design-system/src/main/java/com/goms/design_system/icon/GomsIcon.kt
@@ -138,3 +138,14 @@ fun DeleteIcon(
         modifier = modifier
     )
 }
+
+@Composable
+fun WriteIcon(
+    modifier: Modifier = Modifier
+) {
+    Image(
+        painter = painterResource(id = R.drawable.ic_write),
+        contentDescription = "Write Icon",
+        modifier = modifier
+    )
+}

--- a/core/design-system/src/main/res/drawable/ic_write.xml
+++ b/core/design-system/src/main/res/drawable/ic_write.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M15.891,3.048C17.288,1.651 19.554,1.651 20.952,3.048C22.349,4.445 22.349,6.711 20.952,8.109L20.06,9.001L15,3.94L15.891,3.048ZM13.939,5.001L3.941,15C3.535,15.406 3.249,15.917 3.116,16.476L2.02,21.078C1.96,21.331 2.036,21.598 2.22,21.782C2.404,21.966 2.67,22.041 2.924,21.981L7.525,20.885C8.084,20.752 8.595,20.467 9.002,20.06L19,10.061L13.939,5.001Z"
+      android:fillColor="#2573F3"/>
+</vector>

--- a/core/model/src/main/java/com/goms/model/enum/Class.kt
+++ b/core/model/src/main/java/com/goms/model/enum/Class.kt
@@ -1,0 +1,8 @@
+package com.goms.model.enum
+
+enum class Class(val value: String, val enum: Int) {
+    FIRST("1반", 1),
+    SECOND("2반", 2),
+    THIRD("3반", 3),
+    FOURTH("4반", 4)
+}

--- a/core/model/src/main/java/com/goms/model/enum/Grade.kt
+++ b/core/model/src/main/java/com/goms/model/enum/Grade.kt
@@ -1,0 +1,7 @@
+package com.goms.model.enum
+
+enum class Grade(val value: String, val enum: Int) {
+    FIRST_GRADE("1학년", 1),
+    SECOND_GRADE("2학년", 2),
+    THIRD_GRADE("3학년", 3)
+}

--- a/core/model/src/main/java/com/goms/model/enum/Status.kt
+++ b/core/model/src/main/java/com/goms/model/enum/Status.kt
@@ -1,0 +1,7 @@
+package com.goms.model.enum
+
+enum class Status(val value: String) {
+    ROLE_STUDENT("학생"),
+    ROLE_STUDENT_COUNCIL("학생회"),
+    BLACK_LIST("외출 금지")
+}

--- a/feature/main/src/main/java/com/goms/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/goms/main/MainScreen.kt
@@ -36,7 +36,8 @@ import com.goms.main.viewmodel.MainViewModelProvider
 fun MainRoute(
     viewModelStoreOwner: ViewModelStoreOwner,
     onOutingStatusClick: () -> Unit,
-    onLateListClick: () -> Unit
+    onLateListClick: () -> Unit,
+    onStudentManagementClick: () -> Unit
 ) {
     MainViewModelProvider(viewModelStoreOwner = viewModelStoreOwner) { viewModel ->
         val role by viewModel.role.collectAsStateWithLifecycle(initialValue = "")
@@ -57,7 +58,8 @@ fun MainRoute(
                 viewModel.getOutingCount()
             },
             onOutingStatusClick = onOutingStatusClick,
-            onLateListClick = onLateListClick
+            onLateListClick = onLateListClick,
+            onStudentManagementClick = onStudentManagementClick
         )
     }
 }
@@ -71,7 +73,8 @@ fun MainScreen(
     getOutingCountUiState: GetOutingCountUiState,
     getData: () -> Unit,
     onOutingStatusClick: () -> Unit,
-    onLateListClick: () -> Unit
+    onLateListClick: () -> Unit,
+    onStudentManagementClick: () -> Unit
 ) {
     LaunchedEffect(true) {
         getData()
@@ -92,7 +95,7 @@ fun MainScreen(
                     role = role,
                     icon = { SettingIcon(tint = colors.G7) },
                     onSettingClick = {},
-                    onAdminClick = {}
+                    onAdminClick = { onStudentManagementClick() }
                 )
                 Column(
                     modifier = Modifier

--- a/feature/main/src/main/java/com/goms/main/StudentManagementScreen.kt
+++ b/feature/main/src/main/java/com/goms/main/StudentManagementScreen.kt
@@ -1,0 +1,174 @@
+package com.goms.main
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.goms.design_system.component.bottomsheet.AdminSelectorBottomSheet
+import com.goms.design_system.component.bottomsheet.MultipleSelectorBottomSheet
+import com.goms.design_system.component.button.GomsBackButton
+import com.goms.design_system.component.textfield.GomsSearchTextField
+import com.goms.design_system.theme.GomsTheme
+import com.goms.design_system.util.keyboardAsState
+import com.goms.main.component.StudentManagementList
+import com.goms.main.component.StudentManagementText
+import com.goms.main.viewmodel.MainViewModelProvider
+import com.goms.model.enum.Class
+import com.goms.model.enum.Grade
+import com.goms.model.enum.Status
+
+@Composable
+fun StudentManagementRoute(
+    viewModelStoreOwner: ViewModelStoreOwner,
+    onBackClick: () -> Unit
+) {
+    MainViewModelProvider(viewModelStoreOwner = viewModelStoreOwner) { viewModel ->
+        val studentSearch by viewModel.studentSearch.collectAsStateWithLifecycle()
+        val status by viewModel.status.collectAsStateWithLifecycle()
+        val filterStatus by viewModel.filterStatus.collectAsStateWithLifecycle()
+        val filterGrade by viewModel.filterGrade.collectAsStateWithLifecycle()
+        val filterClass by viewModel.filterClass.collectAsStateWithLifecycle()
+
+        StudentManagementScreen(
+            studentSearch = studentSearch,
+            status = status,
+            filterStatus = filterStatus,
+            filterGrade = filterGrade,
+            filterClass = filterClass,
+            onStudentSearchChange = viewModel::onStudentSearchChange,
+            onStatusChange = viewModel::onStatusChange,
+            onFilterStatusChange = viewModel::onFilterStatusChange,
+            onFilterGradeChange = viewModel::onFilterGradeChange,
+            onFilterClassChange = viewModel::onFilterClassChange,
+            studentSearchCallBack = {},
+            onBackClick = onBackClick,
+        )
+    }
+}
+
+@Composable
+fun StudentManagementScreen(
+    studentSearch: String,
+    status: String,
+    filterStatus: String,
+    filterGrade: String,
+    filterClass: String,
+    onStudentSearchChange: (String) -> Unit,
+    onStatusChange: (String) -> Unit,
+    onFilterStatusChange: (String) -> Unit,
+    onFilterGradeChange: (String) -> Unit,
+    onFilterClassChange: (String) -> Unit,
+    studentSearchCallBack: (String) -> Unit,
+    onBackClick: () -> Unit,
+) {
+    val scrollState = rememberScrollState()
+    val focusManager = LocalFocusManager.current
+    val isKeyboardOpen by keyboardAsState()
+    var onStatusBottomSheetOpenClick by remember { mutableStateOf(false) }
+    var onFilterBottomSheetOpenClick by remember { mutableStateOf(false) }
+
+    LaunchedEffect(isKeyboardOpen) {
+        if (!isKeyboardOpen) {
+            focusManager.clearFocus()
+        }
+    }
+
+    GomsTheme { colors, typography ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(colors.BLACK)
+                .statusBarsPadding()
+                .navigationBarsPadding()
+                .pointerInput(Unit) {
+                    detectTapGestures {
+                        focusManager.clearFocus()
+                    }
+                }
+        ) {
+            GomsBackButton {
+                onBackClick()
+            }
+            Column(
+                modifier = Modifier
+                    .verticalScroll(scrollState)
+                    .padding(horizontal = 20.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                StudentManagementText(modifier = Modifier.align(Alignment.Start))
+                Spacer(modifier = Modifier.height(16.dp))
+                GomsSearchTextField(
+                    modifier = Modifier.fillMaxWidth(),
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
+                    placeHolder = "학생 검색...",
+                    setText = studentSearch,
+                    onValueChange = onStudentSearchChange,
+                    onSearchTextChange = studentSearchCallBack,
+                    singleLine = true
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                StudentManagementList(
+                    onBottomSheetOpenClick = { onFilterBottomSheetOpenClick = true },
+                    onClick = { onStatusBottomSheetOpenClick = true }
+                )
+            }
+        }
+        if (onStatusBottomSheetOpenClick) {
+            AdminSelectorBottomSheet(
+                modifier = Modifier.fillMaxWidth(),
+                title = "유저 권한 변경",
+                subTitle = "역할",
+                list = listOf(Status.ROLE_STUDENT.value, Status.ROLE_STUDENT_COUNCIL.value, Status.BLACK_LIST.value),
+                selected = status,
+                itemChange = onStatusChange,
+                closeSheet = {
+                    onStatusBottomSheetOpenClick = false
+                }
+            )
+        }
+        if (onFilterBottomSheetOpenClick) {
+            MultipleSelectorBottomSheet(
+                modifier = Modifier.fillMaxWidth(),
+                title = "필터",
+                subTitle1 = "역할",
+                list1 = listOf(Status.ROLE_STUDENT.value, Status.ROLE_STUDENT_COUNCIL.value, Status.BLACK_LIST.value),
+                selected1 = filterStatus,
+                itemChange1 = onFilterStatusChange,
+                subTitle2 = "학년",
+                list2 = listOf(Grade.FIRST_GRADE.value, Grade.SECOND_GRADE.value, Grade.THIRD_GRADE.value),
+                selected2 = filterGrade,
+                itemChange2 = onFilterGradeChange,
+                subTitle3 = "반",
+                list3 = listOf(Class.FIRST.value, Class.SECOND.value, Class.THIRD.value, Class.FOURTH.value),
+                selected3 = filterClass,
+                itemChange3 = onFilterClassChange,
+                closeSheet = {
+                    onFilterBottomSheetOpenClick = false
+                }
+            )
+        }
+    }
+}

--- a/feature/main/src/main/java/com/goms/main/component/LateList.kt
+++ b/feature/main/src/main/java/com/goms/main/component/LateList.kt
@@ -32,10 +32,7 @@ fun LateList(
     onBottomSheetOpenClick: () -> Unit
 ) {
     GomsTheme { colors, typography ->
-        Column(
-            modifier = modifier.fillMaxWidth(),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
-        ) {
+        Column(modifier = modifier.fillMaxWidth()) {
             Row(
                 modifier = modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceBetween,

--- a/feature/main/src/main/java/com/goms/main/component/OutingStatusList.kt
+++ b/feature/main/src/main/java/com/goms/main/component/OutingStatusList.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -54,6 +55,7 @@ fun OutingStatusList(
                 OutingListEmptyText()
             }
         }
+
         is GetOutingCountUiState.Success -> {
             when (outingSearchUiState) {
                 OutingSearchUiState.Loading -> Unit
@@ -66,11 +68,12 @@ fun OutingStatusList(
                             val list = getOutingListUiState.getOutingListResponse
 
                             GomsTheme { colors, typography ->
-                                Column(
-                                    modifier = modifier.fillMaxWidth(),
-                                    verticalArrangement = Arrangement.spacedBy(16.dp)
-                                ) {
-                                    SearchResultText(modifier = Modifier.align(Alignment.Start))
+                                Column(modifier = modifier.fillMaxWidth()) {
+                                    SearchResultText(
+                                        modifier = Modifier
+                                            .align(Alignment.Start)
+                                            .height(40.dp)
+                                    )
                                     LazyColumn(
                                         modifier = Modifier
                                             .fillMaxWidth()
@@ -94,24 +97,31 @@ fun OutingStatusList(
                         }
                     }
                 }
+
                 OutingSearchUiState.Empty -> {
                     Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(top = 100.dp)
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalArrangement = Arrangement.spacedBy(60.dp)
                     ) {
+                        SearchResultText(
+                            modifier = Modifier
+                                .align(Alignment.Start)
+                                .height(40.dp)
+                        )
                         SearchEmptyText()
                     }
                 }
+
                 is OutingSearchUiState.Success -> {
                     val list = outingSearchUiState.outingSearchResponse
 
                     GomsTheme { colors, typography ->
-                        Column(
-                            modifier = modifier.fillMaxWidth(),
-                            verticalArrangement = Arrangement.spacedBy(16.dp)
-                        ) {
-                            SearchResultText(modifier = Modifier.align(Alignment.Start))
+                        Column(modifier = modifier.fillMaxWidth()) {
+                            SearchResultText(
+                                modifier = Modifier
+                                    .align(Alignment.Start)
+                                    .height(40.dp)
+                            )
                             LazyColumn(
                                 modifier = Modifier
                                     .fillMaxWidth()

--- a/feature/main/src/main/java/com/goms/main/component/StudentManagementList.kt
+++ b/feature/main/src/main/java/com/goms/main/component/StudentManagementList.kt
@@ -1,0 +1,130 @@
+package com.goms.main.component
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Divider
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.goms.design_system.R
+import com.goms.design_system.icon.WriteIcon
+import com.goms.design_system.theme.GomsTheme
+import com.goms.model.enum.Authority
+import com.goms.model.response.outing.OutingResponse
+import com.goms.ui.toText
+
+@Composable
+fun StudentManagementList(
+    modifier: Modifier = Modifier,
+    onBottomSheetOpenClick: () -> Unit,
+    onClick: () -> Unit
+) {
+    GomsTheme { colors, typography ->
+        Column(modifier = modifier.fillMaxWidth()) {
+            Row(
+                modifier = modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                SearchResultText(modifier = Modifier)
+                FilterText(onFilterTextClick = onBottomSheetOpenClick)
+            }
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 10000.dp)
+            ) {
+//                items(list.size) {
+//                    StudentManagementListItem(
+//                        modifier = Modifier.fillMaxWidth(),
+//                        list = list[it],
+//                        onClick = onClick
+//                    )
+//                    Divider(
+//                        modifier = Modifier.fillMaxWidth(),
+//                        color = colors.WHITE.copy(0.15f)
+//                    )
+//                }
+            }
+        }
+    }
+}
+
+@Composable
+fun StudentManagementListItem(
+    modifier: Modifier = Modifier,
+    role: Authority,
+    list: OutingResponse,
+    onClick: () -> Unit
+) {
+    GomsTheme { colors, typography ->
+        Row(
+            modifier = modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (list.profileUrl.isNullOrEmpty()) {
+                Image(
+                    painter = painterResource(R.drawable.ic_profile),
+                    contentDescription = "Default Profile Image",
+                    modifier = Modifier
+                        .size(48.dp)
+                        .border(
+                            width = 4.dp,
+                            color = if (role == Authority.ROLE_STUDENT_COUNCIL) colors.A7 else Color.Transparent,
+                            shape = CircleShape
+                        )
+                )
+            } else {
+                AsyncImage(
+                    model = list.profileUrl,
+                    modifier = Modifier
+                        .size(48.dp)
+                        .border(
+                            width = 4.dp,
+                            color = if (role == Authority.ROLE_STUDENT_COUNCIL) colors.A7 else Color.Transparent,
+                            shape = CircleShape
+                        ),
+                    contentScale = ContentScale.Crop,
+                    contentDescription = "Profile Image",
+                )
+            }
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text(
+                    text = list.name,
+                    style = typography.textMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = if (role == Authority.ROLE_STUDENT_COUNCIL) colors.A7 else colors.G7
+                )
+                Text(
+                    text = "${list.grade}기 | ${list.major.toText()}",
+                    style = typography.caption,
+                    fontWeight = FontWeight.Normal,
+                    color = colors.G4
+                )
+            }
+            Spacer(modifier = Modifier.weight(1f))
+            IconButton(onClick = { onClick() }) {
+                WriteIcon()
+            }
+        }
+    }
+}

--- a/feature/main/src/main/java/com/goms/main/component/StudentManagementText.kt
+++ b/feature/main/src/main/java/com/goms/main/component/StudentManagementText.kt
@@ -1,0 +1,20 @@
+package com.goms.main.component
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import com.goms.design_system.theme.GomsTheme
+
+@Composable
+fun StudentManagementText(modifier: Modifier) {
+    GomsTheme { colors, typography ->
+        Text(
+            modifier = modifier,
+            text = "학생 관리",
+            style = typography.titleLarge,
+            fontWeight = FontWeight.Bold,
+            color = colors.WHITE
+        )
+    }
+}

--- a/feature/main/src/main/java/com/goms/main/navigation/MainNavigation.kt
+++ b/feature/main/src/main/java/com/goms/main/navigation/MainNavigation.kt
@@ -8,10 +8,12 @@ import androidx.navigation.compose.composable
 import com.goms.main.LateListRoute
 import com.goms.main.MainRoute
 import com.goms.main.OutingStatusRoute
+import com.goms.main.StudentManagementRoute
 
 const val mainRoute = "main_route"
 const val outingStatusRoute = "outing_status_route"
 const val lateListRoute = "late_list_route"
+const val studentManagementRoute = "student_management_route"
 
 fun NavController.navigateToMain(navOptions: NavOptions? = null) {
     this.navigate(mainRoute, navOptions)
@@ -20,13 +22,15 @@ fun NavController.navigateToMain(navOptions: NavOptions? = null) {
 fun NavGraphBuilder.mainScreen(
     viewModelStoreOwner: ViewModelStoreOwner,
     onOutingStatusClick: () -> Unit,
-    onLateListClick: () -> Unit
+    onLateListClick: () -> Unit,
+    onStudentManagementClick: () -> Unit
 ) {
     composable(route = mainRoute) {
         MainRoute(
             viewModelStoreOwner = viewModelStoreOwner,
             onOutingStatusClick = onOutingStatusClick,
-            onLateListClick = onLateListClick
+            onLateListClick = onLateListClick,
+            onStudentManagementClick = onStudentManagementClick
         )
     }
 }
@@ -57,6 +61,22 @@ fun NavGraphBuilder.lateListScreen(
 ) {
     composable(route = lateListRoute) {
         LateListRoute(
+            viewModelStoreOwner = viewModelStoreOwner,
+            onBackClick = onBackClick
+        )
+    }
+}
+
+fun NavController.navigateToStudentManagement(navOptions: NavOptions? = null) {
+    this.navigate(studentManagementRoute, navOptions)
+}
+
+fun NavGraphBuilder.studentManagementScreen(
+    viewModelStoreOwner: ViewModelStoreOwner,
+    onBackClick: () -> Unit
+) {
+    composable(route = studentManagementRoute) {
+        StudentManagementRoute(
             viewModelStoreOwner = viewModelStoreOwner,
             onBackClick = onBackClick
         )

--- a/feature/main/src/main/java/com/goms/main/viewmodel/MainViewModel.kt
+++ b/feature/main/src/main/java/com/goms/main/viewmodel/MainViewModel.kt
@@ -59,6 +59,12 @@ class MainViewModel @Inject constructor(
     val getLateListUiState = _getLateListUiState.asStateFlow()
 
     var outingSearch = savedStateHandle.getStateFlow(key = OUTING_SEARCH, initialValue = "")
+    var studentSearch = savedStateHandle.getStateFlow(key = STUDENT_SEARCH, initialValue = "")
+    var status = savedStateHandle.getStateFlow(key = STATUS, initialValue = "")
+    var filterStatus = savedStateHandle.getStateFlow(key = FILTER_STATUS, initialValue = "")
+    var filterGrade = savedStateHandle.getStateFlow(key = FILTER_GRADE, initialValue = "")
+    var filterClass = savedStateHandle.getStateFlow(key = FILTER_CLASS, initialValue = "")
+
 
     fun getProfile() = viewModelScope.launch {
         getProfileUseCase()
@@ -171,6 +177,30 @@ class MainViewModel @Inject constructor(
     fun onOutingSearchChange(value: String) {
         savedStateHandle[OUTING_SEARCH] = value
     }
+
+    fun onStudentSearchChange(value: String) {
+        savedStateHandle[STUDENT_SEARCH] = value
+    }
+
+    fun onStatusChange(value: String) {
+        savedStateHandle[STATUS] = value
+    }
+
+    fun onFilterStatusChange(value: String) {
+        savedStateHandle[FILTER_STATUS] = value
+    }
+
+    fun onFilterGradeChange(value: String) {
+        savedStateHandle[FILTER_GRADE] = value
+    }
+    fun onFilterClassChange(value: String) {
+        savedStateHandle[FILTER_CLASS] = value
+    }
 }
 
 private const val OUTING_SEARCH = "outing search"
+private const val STUDENT_SEARCH = "student Search"
+private const val STATUS = "status"
+private const val FILTER_STATUS = "filter status"
+private const val FILTER_GRADE = "filter grade"
+private const val FILTER_CLASS = "filter class"

--- a/feature/sign-up/src/main/java/com/goms/sign_up/PasswordScreen.kt
+++ b/feature/sign-up/src/main/java/com/goms/sign_up/PasswordScreen.kt
@@ -79,13 +79,8 @@ fun PasswordRoute(
                             email = "${viewModel.email.value}@gsm.hs.kr",
                             password = viewModel.password.value,
                             name = viewModel.name.value,
-                            gender = if (viewModel.gender.value == Gender.MAN.value) Gender.MAN.name else Gender.WOMAN.name,
-                            major = when (viewModel.major.value) {
-                                Major.SW_DEVELOP.value -> Major.SW_DEVELOP.name
-                                Major.SMART_IOT.value -> Major.SMART_IOT.name
-                                Major.AI.value -> Major.AI.name
-                                else -> ""
-                            },
+                            gender = Gender.values().find { it.value == viewModel.gender.value }!!.name,
+                            major = Major.values().find { it.value == viewModel.major.value }!!.name
                         )
                     )
                 } else {


### PR DESCRIPTION
## 📌 개요
- 학생 관리 퍼블리싱

## 🔀 변경사항
- 학생 관리 페이지 퍼블리싱
- 회원가입 로직에서 enum값을 사용하도록 변경 (find)
- enum class 추가 (Status, Grade, Class)
- student management의 값을 뷰모델에 저장
- 바텀시트 추가

## 📸 구현 화면
[Screen_recording_20240210_175447.webm](https://github.com/team-haribo/GOMS-Android-V2/assets/103114398/69993c73-a652-448e-be86-8ddc2ec37a67)

