### PR TITLE
🔀 :: (#48) - creating skeleton loading

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -30,7 +30,6 @@
             <option value="$PROJECT_DIR$/core/common" />
             <option value="$PROJECT_DIR$/core/data" />
             <option value="$PROJECT_DIR$/core/datastore" />
-            <option value="$PROJECT_DIR$/core/datastore-proto" />
             <option value="$PROJECT_DIR$/core/design-system" />
             <option value="$PROJECT_DIR$/core/domain" />
             <option value="$PROJECT_DIR$/core/model" />
@@ -39,6 +38,8 @@
             <option value="$PROJECT_DIR$/core/ui" />
             <option value="$PROJECT_DIR$/feature" />
             <option value="$PROJECT_DIR$/feature/login" />
+            <option value="$PROJECT_DIR$/feature/main" />
+            <option value="$PROJECT_DIR$/feature/sign-up" />
           </set>
         </option>
       </GradleProjectSettings>

--- a/core/design-system/src/main/java/com/goms/design_system/component/bottomsheet/BottomSheetHeader.kt
+++ b/core/design-system/src/main/java/com/goms/design_system/component/bottomsheet/BottomSheetHeader.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.goms.design_system.component.modifier.gomsClickable
+import com.goms.design_system.component.clickable.gomsClickable
 import com.goms.design_system.icon.CloseIcon
 import com.goms.design_system.theme.GomsTheme
 

--- a/core/design-system/src/main/java/com/goms/design_system/component/button/GomsBackButton.kt
+++ b/core/design-system/src/main/java/com/goms/design_system/component/button/GomsBackButton.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.goms.design_system.component.modifier.gomsClickable
+import com.goms.design_system.component.clickable.gomsClickable
 import com.goms.design_system.icon.BackIcon
 import com.goms.design_system.theme.GomsTheme
 

--- a/core/design-system/src/main/java/com/goms/design_system/component/button/GomsButton.kt
+++ b/core/design-system/src/main/java/com/goms/design_system/component/button/GomsButton.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.goms.design_system.component.modifier.gomsClickable
+import com.goms.design_system.component.clickable.gomsClickable
 import com.goms.design_system.icon.GAuthIcon
 import com.goms.design_system.theme.GomsTheme
 

--- a/core/design-system/src/main/java/com/goms/design_system/component/clickable/MultipleEventsCutter.kt
+++ b/core/design-system/src/main/java/com/goms/design_system/component/clickable/MultipleEventsCutter.kt
@@ -1,4 +1,4 @@
-package com.goms.design_system.component.modifier
+package com.goms.design_system.component.clickable
 
 internal interface MultipleEventsCutter {
     fun processEvent(event: () -> Unit)

--- a/core/design-system/src/main/java/com/goms/design_system/component/clickable/gomsClickable.kt
+++ b/core/design-system/src/main/java/com/goms/design_system/component/clickable/gomsClickable.kt
@@ -1,4 +1,4 @@
-package com.goms.design_system.component.modifier
+package com.goms.design_system.component.clickable
 
 import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.clickable

--- a/core/design-system/src/main/java/com/goms/design_system/component/shimmer/ShimmerBrush.kt
+++ b/core/design-system/src/main/java/com/goms/design_system/component/shimmer/ShimmerBrush.kt
@@ -1,0 +1,44 @@
+package com.goms.design_system.component.shimmer
+
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+
+@Composable
+fun ShimmerBrush(
+    color: Color = Color.LightGray,
+    targetValue: Float = 1300f
+): Brush {
+    val shimmerColors = listOf(
+        color.copy(alpha = 0.15f),
+        color.copy(alpha = 0.13f),
+        color.copy(alpha = 0.1f),
+        color.copy(alpha = 0.13f),
+        color.copy(alpha = 0.15f),
+    )
+
+    val transition = rememberInfiniteTransition()
+    val translateAnimation = transition.animateFloat(
+        initialValue = 0f,
+        targetValue = targetValue,
+        animationSpec = infiniteRepeatable(
+            animation = tween(
+                durationMillis = 1000,
+                easing = FastOutSlowInEasing
+            ), repeatMode = RepeatMode.Restart
+        )
+    )
+
+    return Brush.linearGradient(
+        colors = shimmerColors,
+        start = Offset.Zero,
+        end = Offset(x = translateAnimation.value, y = translateAnimation.value)
+    )
+}

--- a/core/design-system/src/main/java/com/goms/design_system/component/shimmer/shimmerEffect.kt
+++ b/core/design-system/src/main/java/com/goms/design_system/component/shimmer/shimmerEffect.kt
@@ -1,0 +1,20 @@
+package com.goms.design_system.component.shimmer
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+
+fun Modifier.shimmerEffect(
+    color: Color = Color.LightGray,
+    targetValue: Float = 1300f,
+    shape: Shape = CircleShape
+) = composed {
+    val brush = ShimmerBrush(
+        color = color,
+        targetValue = targetValue
+    )
+    this.then(background(brush, shape))
+}

--- a/core/design-system/src/main/java/com/goms/design_system/component/text/LinkText.kt
+++ b/core/design-system/src/main/java/com/goms/design_system/component/text/LinkText.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.goms.design_system.component.modifier.gomsClickable
+import com.goms.design_system.component.clickable.gomsClickable
 import com.goms.design_system.theme.GomsTheme
 
 @Composable

--- a/core/design-system/src/main/java/com/goms/design_system/component/textfield/GomsTextField.kt
+++ b/core/design-system/src/main/java/com/goms/design_system/component/textfield/GomsTextField.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -39,7 +38,7 @@ import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.goms.design_system.component.modifier.gomsClickable
+import com.goms.design_system.component.clickable.gomsClickable
 import com.goms.design_system.component.timer.CountdownTimer
 import com.goms.design_system.icon.SearchIcon
 import com.goms.design_system.theme.GomsTheme

--- a/core/design-system/src/main/java/com/goms/design_system/component/timer/CountdownTimer.kt
+++ b/core/design-system/src/main/java/com/goms/design_system/component/timer/CountdownTimer.kt
@@ -15,7 +15,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.goms.design_system.component.modifier.gomsClickable
+import com.goms.design_system.component.clickable.gomsClickable
 import com.goms.design_system.theme.GomsTheme
 import kotlinx.coroutines.delay
 import java.util.concurrent.TimeUnit

--- a/core/ui/src/main/java/com/goms/ui/GomsTopBar.kt
+++ b/core/ui/src/main/java/com/goms/ui/GomsTopBar.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.goms.design_system.component.modifier.gomsClickable
+import com.goms.design_system.component.clickable.gomsClickable
 import com.goms.design_system.icon.GomsTextIcon
 import com.goms.design_system.icon.PersonIcon
 import com.goms.design_system.icon.SettingIcon

--- a/feature/main/src/main/java/com/goms/main/component/FilterText.kt
+++ b/feature/main/src/main/java/com/goms/main/component/FilterText.kt
@@ -8,7 +8,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.goms.design_system.component.modifier.gomsClickable
+import com.goms.design_system.component.clickable.gomsClickable
 import com.goms.design_system.theme.GomsTheme
 
 @Composable

--- a/feature/main/src/main/java/com/goms/main/component/LateList.kt
+++ b/feature/main/src/main/java/com/goms/main/component/LateList.kt
@@ -2,12 +2,16 @@ package com.goms.main.component
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Divider
 import androidx.compose.material3.Text
@@ -20,6 +24,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.goms.design_system.R
+import com.goms.design_system.component.shimmer.shimmerEffect
 import com.goms.design_system.theme.GomsTheme
 import com.goms.main.viewmodel.GetLateListUiState
 import com.goms.model.response.council.LateResponse
@@ -42,7 +47,21 @@ fun LateList(
                 FilterText(onFilterTextClick = onBottomSheetOpenClick)
             }
             when (getLateListUiState) {
-                GetLateListUiState.Loading -> Unit
+                GetLateListUiState.Loading -> {
+                    LazyColumn(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .heightIn(max = 10000.dp)
+                    ) {
+                        items(10) {
+                            ShimmerLateListItem(modifier = modifier)
+                            Divider(
+                                modifier = Modifier.fillMaxWidth(),
+                                color = colors.WHITE.copy(0.15f)
+                            )
+                        }
+                    }
+                }
                 is GetLateListUiState.Error -> Unit
                 GetLateListUiState.Empty -> {
                     Column(
@@ -115,6 +134,37 @@ fun LateListItem(
                     style = typography.caption,
                     fontWeight = FontWeight.Normal,
                     color = colors.G4
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun ShimmerLateListItem(modifier: Modifier) {
+    GomsTheme { colors, typography ->
+        Row(
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(48.dp)
+                    .shimmerEffect(color = colors.WHITE)
+            )
+            Spacer(modifier = Modifier.width(16.dp))
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Box(
+                    modifier = Modifier
+                        .size(42.dp, 18.dp)
+                        .shimmerEffect(color = colors.WHITE)
+                )
+                Box(
+                    modifier = Modifier
+                        .size(50.dp, 14.dp)
+                        .shimmerEffect(color = colors.WHITE)
                 )
             }
         }

--- a/feature/main/src/main/java/com/goms/main/component/MainLateCard.kt
+++ b/feature/main/src/main/java/com/goms/main/component/MainLateCard.kt
@@ -28,10 +28,9 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import com.goms.design_system.R
-import com.goms.design_system.component.modifier.gomsClickable
+import com.goms.design_system.component.clickable.gomsClickable
 import com.goms.design_system.theme.GomsTheme
 import com.goms.main.viewmodel.GetLateRankListUiState
 import com.goms.model.enum.Authority

--- a/feature/main/src/main/java/com/goms/main/component/MainLateCard.kt
+++ b/feature/main/src/main/java/com/goms/main/component/MainLateCard.kt
@@ -3,6 +3,7 @@ package com.goms.main.component
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -31,6 +32,7 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.goms.design_system.R
 import com.goms.design_system.component.clickable.gomsClickable
+import com.goms.design_system.component.shimmer.shimmerEffect
 import com.goms.design_system.theme.GomsTheme
 import com.goms.main.viewmodel.GetLateRankListUiState
 import com.goms.model.enum.Authority
@@ -44,67 +46,72 @@ fun MainLateCard(
     getLateRankListUiState: GetLateRankListUiState,
     onClick: () -> Unit
 ) {
-    when (getLateRankListUiState) {
-        GetLateRankListUiState.Loading -> Unit
-        is GetLateRankListUiState.Error -> Unit
-        is GetLateRankListUiState.Success -> {
-            val list = getLateRankListUiState.getLateRankListResponse
+    var componentWidth by remember { mutableStateOf(0.dp) }
+    val density = LocalDensity.current
 
-            var componentWidth by remember { mutableStateOf(0.dp) }
-            val density = LocalDensity.current
-
-            GomsTheme { colors, typography ->
-                Surface(
-                    modifier = modifier
-                        .onGloballyPositioned {
-                            componentWidth = with(density) {
-                                it.size.width.toDp()
-                            }
-                        },
-                    color = colors.G1,
-                    shape = RoundedCornerShape(12.dp),
-                    border = BorderStroke(width = 1.dp, color = colors.WHITE.copy(0.15f))
+    GomsTheme { colors, typography ->
+        Surface(
+            modifier = modifier
+                .onGloballyPositioned {
+                    componentWidth = with(density) {
+                        it.size.width.toDp()
+                    }
+                },
+            color = colors.G1,
+            shape = RoundedCornerShape(12.dp),
+            border = BorderStroke(width = 1.dp, color = colors.WHITE.copy(0.15f))
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(16.dp),
-                    ) {
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Text(
-                                text = "지각자 TOP 3",
-                                style = typography.titleMedium,
-                                fontWeight = FontWeight.Bold,
-                                color = colors.WHITE
-                            )
-                            if (role == Authority.ROLE_STUDENT_COUNCIL) {
-                                Text(
-                                    modifier = Modifier.gomsClickable { onClick() },
-                                    text = "더보기",
-                                    style = typography.buttonSmall,
-                                    fontWeight = FontWeight.Normal,
-                                    color = colors.G7
-                                )
-                            }
-                        }
-                        Spacer(modifier = Modifier.height(16.dp))
-                        if (list.isEmpty()) {
-                            LateListEmptyText()
-                        } else {
-                            LazyRow(modifier = Modifier.fillMaxWidth()) {
-                                items(list.take(3).size) {
-                                    MainLateItem(
-                                        modifier = Modifier.widthIn((componentWidth - 32.dp) / 3),
-                                        list = list[it]
-                                    )
-                                }
+                    Text(
+                        text = "지각자 TOP 3",
+                        style = typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = colors.WHITE
+                    )
+                    if (role == Authority.ROLE_STUDENT_COUNCIL) {
+                        Text(
+                            modifier = Modifier.gomsClickable { onClick() },
+                            text = "더보기",
+                            style = typography.buttonSmall,
+                            fontWeight = FontWeight.Normal,
+                            color = colors.G7
+                        )
+                    }
+                }
+                Spacer(modifier = Modifier.height(16.dp))
+                when (getLateRankListUiState) {
+                    GetLateRankListUiState.Loading -> {
+                        LazyRow(modifier = Modifier.fillMaxWidth()) {
+                            items(3) {
+                                ShimmerMainLateItem(modifier = Modifier.widthIn((componentWidth - 32.dp) / 3))
                             }
                         }
                     }
+                    GetLateRankListUiState.Empty -> {
+                        LateListEmptyText()
+                    }
+                    is GetLateRankListUiState.Success -> {
+                        val list = getLateRankListUiState.getLateRankListResponse
+
+                        LazyRow(modifier = Modifier.fillMaxWidth()) {
+                            items(list.take(3).size) {
+                                MainLateItem(
+                                    modifier = Modifier.widthIn((componentWidth - 32.dp) / 3),
+                                    list = list[it]
+                                )
+                            }
+                        }
+                    }
+                    is GetLateRankListUiState.Error -> Unit
                 }
             }
         }
@@ -147,6 +154,33 @@ fun MainLateItem(
                 style = typography.caption,
                 fontWeight = FontWeight.Normal,
                 color = colors.G4
+            )
+        }
+    }
+}
+
+@Composable
+fun ShimmerMainLateItem(modifier: Modifier) {
+    GomsTheme { colors, typography ->
+        Column(
+            modifier = modifier.padding(vertical = 16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(56.dp)
+                    .shimmerEffect(color = colors.WHITE)
+            )
+            Box(
+                modifier = Modifier
+                    .size(56.dp, 23.dp)
+                    .shimmerEffect(color = colors.WHITE)
+            )
+            Box(
+                modifier = Modifier
+                    .size(60.dp, 16.dp)
+                    .shimmerEffect(color = colors.WHITE)
             )
         }
     }

--- a/feature/main/src/main/java/com/goms/main/component/MainOutingCard.kt
+++ b/feature/main/src/main/java/com/goms/main/component/MainOutingCard.kt
@@ -3,6 +3,7 @@ package com.goms.main.component
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -25,6 +26,7 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.goms.design_system.R
 import com.goms.design_system.component.clickable.gomsClickable
+import com.goms.design_system.component.shimmer.shimmerEffect
 import com.goms.design_system.theme.GomsTheme
 import com.goms.main.viewmodel.GetOutingCountUiState
 import com.goms.main.viewmodel.GetOutingListUiState
@@ -40,53 +42,59 @@ fun MainOutingCard(
     getOutingCountUiState: GetOutingCountUiState,
     onClick: () -> Unit
 ) {
-    when (getOutingCountUiState) {
-        GetOutingCountUiState.Loading -> Unit
-        is GetOutingCountUiState.Error -> Unit
-        GetOutingCountUiState.Empty -> {
-            GomsTheme { colors, typography ->
-                Surface(
-                    modifier = modifier,
-                    color = colors.G1,
-                    shape = RoundedCornerShape(12.dp),
-                    border = BorderStroke(width = 1.dp, color = colors.WHITE.copy(0.15f))
+    GomsTheme { colors, typography ->
+        Surface(
+            modifier = modifier,
+            color = colors.G1,
+            shape = RoundedCornerShape(12.dp),
+            border = BorderStroke(width = 1.dp, color = colors.WHITE.copy(0.15f))
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(6.dp)
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(16.dp),
-                        verticalArrangement = Arrangement.spacedBy(6.dp)
-                    ) {
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Text(
-                                text = "외출 현황",
-                                style = typography.titleMedium,
-                                fontWeight = FontWeight.Bold,
-                                color = colors.WHITE
+                    Text(
+                        text = "외출 현황",
+                        style = typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = colors.WHITE
+                    )
+                    if (role == Authority.ROLE_STUDENT) {
+                        Text(
+                            modifier = Modifier.gomsClickable { onClick() },
+                            text = "더보기",
+                            style = typography.buttonSmall,
+                            fontWeight = FontWeight.Normal,
+                            color = colors.G7
+                        )
+                    } else {
+                        Text(
+                            modifier = Modifier.gomsClickable { onClick() },
+                            text = "인원 관리하기",
+                            style = typography.buttonSmall,
+                            fontWeight = FontWeight.Normal,
+                            color = colors.G7
+                        )
+                    }
+                }
+                Divider(modifier = Modifier.height(1.dp), color = colors.WHITE.copy(0.15f))
+                when (getOutingCountUiState) {
+                    GetOutingCountUiState.Loading -> {
+                            Box(
+                                modifier = Modifier
+                                    .size(56.dp, 23.dp)
+                                    .shimmerEffect(color = colors.WHITE)
                             )
-                            if (role == Authority.ROLE_STUDENT) {
-                                Text(
-                                    modifier = Modifier.gomsClickable { onClick() },
-                                    text = "더보기",
-                                    style = typography.buttonSmall,
-                                    fontWeight = FontWeight.Normal,
-                                    color = colors.G7
-                                )
-                            } else {
-                                Text(
-                                    modifier = Modifier.gomsClickable { onClick() },
-                                    text = "인원 관리하기",
-                                    style = typography.buttonSmall,
-                                    fontWeight = FontWeight.Normal,
-                                    color = colors.G7
-                                )
-                            }
-                        }
-                        Divider(modifier = Modifier.height(1.dp), color = colors.WHITE.copy(0.15f))
+                    }
+                    is GetOutingCountUiState.Error -> Unit
+                    GetOutingCountUiState.Empty -> {
                         Row(
                             modifier = Modifier.fillMaxWidth(),
                             verticalAlignment = Alignment.CenterVertically
@@ -105,60 +113,29 @@ fun MainOutingCard(
                             )
                         }
                     }
-                }
-            }
-        }
-        is GetOutingCountUiState.Success -> {
-            when (getOutingListUiState) {
-                GetOutingListUiState.Loading -> Unit
-                is GetOutingListUiState.Error -> Unit
-                is GetOutingListUiState.Success -> {
-                    val count = getOutingCountUiState.getOutingCountResponse
-                    val list = getOutingListUiState.getOutingListResponse
-
-                    GomsTheme { colors, typography ->
-                        Surface(
-                            modifier = modifier,
-                            color = colors.G1,
-                            shape = RoundedCornerShape(12.dp),
-                            border = BorderStroke(width = 1.dp, color = colors.WHITE.copy(0.15f))
-                        ) {
-                            Column(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(16.dp),
-                                verticalArrangement = Arrangement.spacedBy(6.dp)
-                            ) {
-                                Row(
-                                    modifier = Modifier.fillMaxWidth(),
-                                    horizontalArrangement = Arrangement.SpaceBetween,
-                                    verticalAlignment = Alignment.CenterVertically
+                    is GetOutingCountUiState.Success -> {
+                        when (getOutingListUiState) {
+                            GetOutingListUiState.Loading -> {
+                                Box(
+                                    modifier = Modifier
+                                        .size(56.dp, 23.dp)
+                                        .shimmerEffect(color = colors.WHITE)
+                                )
+                                LazyColumn(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .heightIn(max = 10000.dp)
                                 ) {
-                                    Text(
-                                        text = "외출 현황",
-                                        style = typography.titleMedium,
-                                        fontWeight = FontWeight.Bold,
-                                        color = colors.WHITE
-                                    )
-                                    if (role == Authority.ROLE_STUDENT) {
-                                        Text(
-                                            modifier = Modifier.gomsClickable { onClick() },
-                                            text = "더보기",
-                                            style = typography.buttonSmall,
-                                            fontWeight = FontWeight.Normal,
-                                            color = colors.G7
-                                        )
-                                    } else {
-                                        Text(
-                                            modifier = Modifier.gomsClickable { onClick() },
-                                            text = "인원 관리하기",
-                                            style = typography.buttonSmall,
-                                            fontWeight = FontWeight.Normal,
-                                            color = colors.G7
-                                        )
+                                    items(5) {
+                                        ShimmerMainOutingItem(modifier = modifier)
                                     }
                                 }
-                                Divider(modifier = Modifier.height(1.dp), color = colors.WHITE.copy(0.15f))
+                            }
+                            is GetOutingListUiState.Error -> Unit
+                            is GetOutingListUiState.Success -> {
+                                val count = getOutingCountUiState.getOutingCountResponse
+                                val list = getOutingListUiState.getOutingListResponse
+
                                 Row(
                                     modifier = Modifier.fillMaxWidth(),
                                     verticalAlignment = Alignment.CenterVertically
@@ -233,6 +210,35 @@ fun MainOutingItem(
                 style = typography.caption,
                 fontWeight = FontWeight.Normal,
                 color = colors.G4
+            )
+        }
+    }
+}
+
+@Composable
+fun ShimmerMainOutingItem(
+    modifier: Modifier = Modifier,
+) {
+    GomsTheme { colors, typography ->
+        Row(
+            modifier = modifier.padding(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(28.dp)
+                    .shimmerEffect(color = colors.WHITE)
+            )
+            Box(
+                modifier = Modifier
+                    .size(56.dp, 23.dp)
+                    .shimmerEffect(color = colors.WHITE)
+            )
+            Box(
+                modifier = Modifier
+                    .size(60.dp, 16.dp)
+                    .shimmerEffect(color = colors.WHITE)
             )
         }
     }

--- a/feature/main/src/main/java/com/goms/main/component/MainOutingCard.kt
+++ b/feature/main/src/main/java/com/goms/main/component/MainOutingCard.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.goms.design_system.R
-import com.goms.design_system.component.modifier.gomsClickable
+import com.goms.design_system.component.clickable.gomsClickable
 import com.goms.design_system.theme.GomsTheme
 import com.goms.main.viewmodel.GetOutingCountUiState
 import com.goms.main.viewmodel.GetOutingListUiState

--- a/feature/main/src/main/java/com/goms/main/component/MainProfileCard.kt
+++ b/feature/main/src/main/java/com/goms/main/component/MainProfileCard.kt
@@ -3,6 +3,7 @@ package com.goms.main.component
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -24,8 +25,10 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.goms.design_system.theme.GomsTheme
 import com.goms.design_system.R
+import com.goms.design_system.component.shimmer.shimmerEffect
 import com.goms.main.viewmodel.GetProfileUiState
 import com.goms.model.enum.Authority
+import com.goms.model.response.account.ProfileResponse
 import com.goms.ui.toText
 
 @Composable
@@ -34,76 +37,135 @@ fun MainProfileCard(
     getProfileUiState: GetProfileUiState,
 ) {
     when (getProfileUiState) {
-        GetProfileUiState.Loading -> Unit
-        is GetProfileUiState.Error -> Unit
+        GetProfileUiState.Loading -> {
+            ShimmerMainProfileCardComponent(modifier = modifier)
+        }
         is GetProfileUiState.Success -> {
             val data = getProfileUiState.getProfileResponse
 
-            GomsTheme { colors, typography ->
+            MainProfileCardComponent(
+                modifier = modifier,
+                data = data
+            )
+        }
+        is GetProfileUiState.Error -> Unit
+    }
+}
 
-                val stateColor = if (data.isBlackList) colors.N5
-                else if (data.isOuting) colors.P5
-                else if (data.authority == Authority.ROLE_STUDENT_COUNCIL) colors.A7
-                else colors.G4
+@Composable
+fun MainProfileCardComponent(
+    modifier: Modifier,
+    data: ProfileResponse
+) {
+    GomsTheme { colors, typography ->
+        val stateColor = if (data.isBlackList) colors.N5
+        else if (data.isOuting) colors.P5
+        else if (data.authority == Authority.ROLE_STUDENT_COUNCIL) colors.A7
+        else colors.G4
 
-                val stateText = if (data.isBlackList) "외출 금지"
-                else if (data.isOuting) "외출 중"
-                else if (data.authority == Authority.ROLE_STUDENT_COUNCIL) "학생회"
-                else "외출 대기 중"
+        val stateText = if (data.isBlackList) "외출 금지"
+        else if (data.isOuting) "외출 중"
+        else if (data.authority == Authority.ROLE_STUDENT_COUNCIL) "학생회"
+        else "외출 대기 중"
 
-                Surface(
-                    modifier = modifier,
-                    color = colors.G1,
-                    shape = RoundedCornerShape(12.dp),
-                    border = BorderStroke(width = 1.dp, color = colors.WHITE.copy(0.15f))
-                ) {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(16.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        if (data.profileUrl.isNullOrEmpty()) {
-                            Image(
-                                painter = painterResource(R.drawable.ic_profile),
-                                contentDescription = "Default Profile Image",
-                                modifier = Modifier.size(64.dp)
-                            )
-                        } else {
-                            AsyncImage(
-                                model = data.profileUrl,
-                                modifier = Modifier.size(64.dp),
-                                contentScale = ContentScale.Crop,
-                                contentDescription = "Profile Image",
-                            )
-                        }
-                        Spacer(modifier = Modifier.width(16.dp))
-                        Column(
-                            modifier = Modifier.height(56.dp),
-                            verticalArrangement = Arrangement.SpaceBetween
-                        ) {
-                            Text(
-                                text = data.name,
-                                style = typography.titleSmall,
-                                fontWeight = FontWeight.SemiBold,
-                                color = colors.WHITE
-                            )
-                            Text(
-                                text = "${data.grade}기 | ${data.major.toText()}",
-                                style = typography.textMedium,
-                                fontWeight = FontWeight.Normal,
-                                color = colors.G4
-                            )
-                        }
-                        Spacer(modifier = Modifier.weight(1f))
-                        Text(
-                            text = stateText,
-                            style = typography.titleSmall,
-                            fontWeight = FontWeight.SemiBold,
-                            color = stateColor
-                        )
-                    }
+        Surface(
+            modifier = modifier,
+            color = colors.G1,
+            shape = RoundedCornerShape(12.dp),
+            border = BorderStroke(width = 1.dp, color = colors.WHITE.copy(0.15f))
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                if (data.profileUrl.isNullOrEmpty()) {
+                    Image(
+                        painter = painterResource(R.drawable.ic_profile),
+                        contentDescription = "Default Profile Image",
+                        modifier = Modifier.size(64.dp)
+                    )
+                } else {
+                    AsyncImage(
+                        model = data.profileUrl,
+                        modifier = Modifier.size(64.dp),
+                        contentScale = ContentScale.Crop,
+                        contentDescription = "Profile Image",
+                    )
                 }
+                Spacer(modifier = Modifier.width(16.dp))
+                Column(
+                    modifier = Modifier.height(56.dp),
+                    verticalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text(
+                        text = data.name,
+                        style = typography.titleSmall,
+                        fontWeight = FontWeight.SemiBold,
+                        color = colors.WHITE
+                    )
+                    Text(
+                        text = "${data.grade}기 | ${data.major.toText()}",
+                        style = typography.textMedium,
+                        fontWeight = FontWeight.Normal,
+                        color = colors.G4
+                    )
+                }
+                Spacer(modifier = Modifier.weight(1f))
+                Text(
+                    text = stateText,
+                    style = typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    color = stateColor
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun ShimmerMainProfileCardComponent(modifier: Modifier) {
+    GomsTheme { colors, typography ->
+        Surface(
+            modifier = modifier,
+            color = colors.G1,
+            shape = RoundedCornerShape(12.dp),
+            border = BorderStroke(width = 1.dp, color = colors.WHITE.copy(0.15f))
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(64.dp)
+                        .shimmerEffect(color = colors.WHITE)
+                )
+                Spacer(modifier = Modifier.width(16.dp))
+                Column(
+                    modifier = Modifier.height(56.dp),
+                    verticalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .size(50.dp, 28.dp)
+                            .shimmerEffect(color = colors.WHITE)
+                    )
+                    Box(
+                        modifier = Modifier
+                            .size(88.dp, 23.dp)
+                            .shimmerEffect(color = colors.WHITE)
+                    )
+                }
+                Spacer(modifier = Modifier.weight(1f))
+                Box(
+                    modifier = Modifier
+                        .size(92.dp, 28.dp)
+                        .shimmerEffect(color = colors.WHITE)
+                )
             }
         }
     }

--- a/feature/main/src/main/java/com/goms/main/component/OutingStatusList.kt
+++ b/feature/main/src/main/java/com/goms/main/component/OutingStatusList.kt
@@ -2,6 +2,7 @@ package com.goms.main.component
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -10,6 +11,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Divider
 import androidx.compose.material3.IconButton
@@ -23,6 +25,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.goms.design_system.R
+import com.goms.design_system.component.shimmer.shimmerEffect
 import com.goms.design_system.icon.DeleteIcon
 import com.goms.design_system.theme.GomsTheme
 import com.goms.design_system.util.formatTime
@@ -44,7 +47,9 @@ fun OutingStatusList(
     onClick: (UUID) -> Unit
 ) {
     when (getOutingCountUiState) {
-        GetOutingCountUiState.Loading -> Unit
+        GetOutingCountUiState.Loading -> {
+            ShimmerOutingStatusListComponent(modifier = modifier)
+        }
         is GetOutingCountUiState.Error -> Unit
         GetOutingCountUiState.Empty -> {
             Column(
@@ -55,49 +60,30 @@ fun OutingStatusList(
                 OutingListEmptyText()
             }
         }
-
         is GetOutingCountUiState.Success -> {
             when (outingSearchUiState) {
-                OutingSearchUiState.Loading -> Unit
+                OutingSearchUiState.Loading -> {
+                    ShimmerOutingStatusListComponent(modifier = modifier)
+                }
                 is OutingSearchUiState.Error -> Unit
                 OutingSearchUiState.QueryEmpty -> {
                     when (getOutingListUiState) {
-                        GetOutingListUiState.Loading -> Unit
+                        GetOutingListUiState.Loading -> {
+                            ShimmerOutingStatusListComponent(modifier = modifier)
+                        }
                         is GetOutingListUiState.Error -> Unit
                         is GetOutingListUiState.Success -> {
                             val list = getOutingListUiState.getOutingListResponse
 
-                            GomsTheme { colors, typography ->
-                                Column(modifier = modifier.fillMaxWidth()) {
-                                    SearchResultText(
-                                        modifier = Modifier
-                                            .align(Alignment.Start)
-                                            .height(40.dp)
-                                    )
-                                    LazyColumn(
-                                        modifier = Modifier
-                                            .fillMaxWidth()
-                                            .heightIn(max = 10000.dp)
-                                    ) {
-                                        items(list.size) {
-                                            OutingStatusListItem(
-                                                modifier = Modifier.fillMaxWidth(),
-                                                role = role,
-                                                list = list[it],
-                                                onClick = onClick
-                                            )
-                                            Divider(
-                                                modifier = Modifier.fillMaxWidth(),
-                                                color = colors.WHITE.copy(0.15f)
-                                            )
-                                        }
-                                    }
-                                }
-                            }
+                            OutingStatusListComponent(
+                                modifier = modifier,
+                                role = role,
+                                list = list,
+                                onClick = onClick
+                            )
                         }
                     }
                 }
-
                 OutingSearchUiState.Empty -> {
                     Column(
                         modifier = Modifier.fillMaxWidth(),
@@ -111,37 +97,51 @@ fun OutingStatusList(
                         SearchEmptyText()
                     }
                 }
-
                 is OutingSearchUiState.Success -> {
                     val list = outingSearchUiState.outingSearchResponse
 
-                    GomsTheme { colors, typography ->
-                        Column(modifier = modifier.fillMaxWidth()) {
-                            SearchResultText(
-                                modifier = Modifier
-                                    .align(Alignment.Start)
-                                    .height(40.dp)
-                            )
-                            LazyColumn(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .heightIn(max = 10000.dp)
-                            ) {
-                                items(list.size) {
-                                    OutingStatusListItem(
-                                        modifier = Modifier.fillMaxWidth(),
-                                        role = role,
-                                        list = list[it],
-                                        onClick = onClick
-                                    )
-                                    Divider(
-                                        modifier = Modifier.fillMaxWidth(),
-                                        color = colors.WHITE.copy(0.15f)
-                                    )
-                                }
-                            }
-                        }
-                    }
+                    OutingStatusListComponent(
+                        modifier = modifier,
+                        role = role,
+                        list = list,
+                        onClick = onClick
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun OutingStatusListComponent(
+    modifier: Modifier,
+    role: Authority,
+    list: List<OutingResponse>,
+    onClick: (UUID) -> Unit
+) {
+    GomsTheme { colors, typography ->
+        Column(modifier = modifier.fillMaxWidth()) {
+            SearchResultText(
+                modifier = Modifier
+                    .align(Alignment.Start)
+                    .height(40.dp)
+            )
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 10000.dp)
+            ) {
+                items(list.size) {
+                    OutingStatusListItem(
+                        modifier = Modifier.fillMaxWidth(),
+                        role = role,
+                        list = list[it],
+                        onClick = onClick
+                    )
+                    Divider(
+                        modifier = Modifier.fillMaxWidth(),
+                        color = colors.WHITE.copy(0.15f)
+                    )
                 }
             }
         }
@@ -209,6 +209,63 @@ fun OutingStatusListItem(
                 IconButton(onClick = { onClick(UUID.fromString(list.accountIdx)) }) {
                     DeleteIcon()
                 }
+            }
+        }
+    }
+}
+
+@Composable
+fun ShimmerOutingStatusListComponent(modifier: Modifier) {
+    GomsTheme { colors, typography ->
+        Column(modifier = modifier.fillMaxWidth()) {
+            SearchResultText(
+                modifier = Modifier
+                    .align(Alignment.Start)
+                    .height(40.dp)
+            )
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 10000.dp)
+            ) {
+                items(10) {
+                    ShimmerOutingStatusListItem(modifier = modifier)
+                    Divider(
+                        modifier = Modifier.fillMaxWidth(),
+                        color = colors.WHITE.copy(0.15f)
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun ShimmerOutingStatusListItem(modifier: Modifier) {
+    GomsTheme { colors, typography ->
+        Row(
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(48.dp)
+                    .shimmerEffect(color = colors.WHITE)
+            )
+            Spacer(modifier = Modifier.width(16.dp))
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Box(
+                    modifier = Modifier
+                        .size(42.dp, 18.dp)
+                        .shimmerEffect(color = colors.WHITE)
+                )
+                Box(
+                    modifier = Modifier
+                        .size(120.dp, 14.dp)
+                        .shimmerEffect(color = colors.WHITE)
+                )
             }
         }
     }

--- a/feature/main/src/main/java/com/goms/main/component/StudentManagementList.kt
+++ b/feature/main/src/main/java/com/goms/main/component/StudentManagementList.kt
@@ -3,13 +3,16 @@ package com.goms.main.component
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Divider
@@ -25,6 +28,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.goms.design_system.R
+import com.goms.design_system.component.shimmer.shimmerEffect
 import com.goms.design_system.icon.WriteIcon
 import com.goms.design_system.theme.GomsTheme
 import com.goms.main.viewmodel.GetStudentListUiState
@@ -44,44 +48,25 @@ fun StudentManagementList(
     onClick: (UUID, String) -> Unit
 ) {
     when (studentSearchUiState) {
-        StudentSearchUiState.Loading -> Unit
+        StudentSearchUiState.Loading -> {
+            ShimmerStudentManagementListComponent(modifier = modifier)
+        }
         is StudentSearchUiState.Error -> Unit
         StudentSearchUiState.QueryEmpty -> {
             when (getStudentListUiState) {
-                GetStudentListUiState.Loading -> Unit
+                GetStudentListUiState.Loading -> {
+                    ShimmerStudentManagementListComponent(modifier = modifier)
+                }
                 is GetStudentListUiState.Error -> Unit
                 is GetStudentListUiState.Success -> {
                     val list = getStudentListUiState.getStudentResponse
 
-                    GomsTheme { colors, typography ->
-                        Column(modifier = modifier.fillMaxWidth()) {
-                            Row(
-                                modifier = modifier.fillMaxWidth(),
-                                horizontalArrangement = Arrangement.SpaceBetween,
-                                verticalAlignment = Alignment.CenterVertically
-                            ) {
-                                SearchResultText(modifier = Modifier)
-                                FilterText(onFilterTextClick = onBottomSheetOpenClick)
-                            }
-                            LazyColumn(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .heightIn(max = 10000.dp)
-                            ) {
-                                items(list.size) {
-                                    StudentManagementListItem(
-                                        modifier = Modifier.fillMaxWidth(),
-                                        list = list[it],
-                                        onClick = onClick
-                                    )
-                                    Divider(
-                                        modifier = Modifier.fillMaxWidth(),
-                                        color = colors.WHITE.copy(0.15f)
-                                    )
-                                }
-                            }
-                        }
-                    }
+                    StudentManagementListComponent(
+                        modifier = modifier,
+                        list = list,
+                        onBottomSheetOpenClick = onBottomSheetOpenClick,
+                        onClick = onClick
+                    )
                 }
             }
         }
@@ -104,33 +89,48 @@ fun StudentManagementList(
         is StudentSearchUiState.Success -> {
             val list = studentSearchUiState.studentSearchResponse
 
-            GomsTheme { colors, typography ->
-                Column(modifier = modifier.fillMaxWidth()) {
-                    Row(
-                        modifier = modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        SearchResultText(modifier = Modifier)
-                        FilterText(onFilterTextClick = onBottomSheetOpenClick)
-                    }
-                    LazyColumn(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .heightIn(max = 10000.dp)
-                    ) {
-                        items(list.size) {
-                            StudentManagementListItem(
-                                modifier = Modifier.fillMaxWidth(),
-                                list = list[it],
-                                onClick = onClick
-                            )
-                            Divider(
-                                modifier = Modifier.fillMaxWidth(),
-                                color = colors.WHITE.copy(0.15f)
-                            )
-                        }
-                    }
+            StudentManagementListComponent(
+                modifier = modifier,
+                list = list,
+                onBottomSheetOpenClick = onBottomSheetOpenClick,
+                onClick = onClick
+            )
+        }
+    }
+}
+
+@Composable
+fun StudentManagementListComponent(
+    modifier: Modifier,
+    list: List<StudentResponse>,
+    onBottomSheetOpenClick: () -> Unit,
+    onClick: (UUID, String) -> Unit
+) {
+    GomsTheme { colors, typography ->
+        Column(modifier = modifier.fillMaxWidth()) {
+            Row(
+                modifier = modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                SearchResultText(modifier = Modifier)
+                FilterText(onFilterTextClick = onBottomSheetOpenClick)
+            }
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 10000.dp)
+            ) {
+                items(list.size) {
+                    StudentManagementListItem(
+                        modifier = Modifier.fillMaxWidth(),
+                        list = list[it],
+                        onClick = onClick
+                    )
+                    Divider(
+                        modifier = Modifier.fillMaxWidth(),
+                        color = colors.WHITE.copy(0.15f)
+                    )
                 }
             }
         }
@@ -205,6 +205,66 @@ fun StudentManagementListItem(
                 )
             }) {
                 WriteIcon()
+            }
+        }
+    }
+}
+
+@Composable
+fun ShimmerStudentManagementListComponent(modifier: Modifier) {
+    GomsTheme { colors, typography ->
+        Column(modifier = modifier.fillMaxWidth()) {
+            Row(
+                modifier = modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                SearchResultText(modifier = Modifier)
+                FilterText(onFilterTextClick = {})
+            }
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 10000.dp)
+            ) {
+                items(10) {
+                    ShimmerStudentManagementListItem(modifier = modifier)
+                    Divider(
+                        modifier = Modifier.fillMaxWidth(),
+                        color = colors.WHITE.copy(0.15f)
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun ShimmerStudentManagementListItem(modifier: Modifier) {
+    GomsTheme { colors, typography ->
+        Row(
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(48.dp)
+                    .shimmerEffect(color = colors.WHITE)
+            )
+            Spacer(modifier = Modifier.width(16.dp))
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Box(
+                    modifier = Modifier
+                        .size(42.dp, 18.dp)
+                        .shimmerEffect(color = colors.WHITE)
+                )
+                Box(
+                    modifier = Modifier
+                        .size(50.dp, 14.dp)
+                        .shimmerEffect(color = colors.WHITE)
+                )
             }
         }
     }

--- a/feature/main/src/main/java/com/goms/main/viewmodel/GetLateRankListUiState.kt
+++ b/feature/main/src/main/java/com/goms/main/viewmodel/GetLateRankListUiState.kt
@@ -4,6 +4,7 @@ import com.goms.model.response.late.RankResponse
 
 sealed interface GetLateRankListUiState {
     object Loading : GetLateRankListUiState
+    object Empty : GetLateRankListUiState
     data class Success(val getLateRankListResponse: List<RankResponse>) : GetLateRankListUiState
     data class Error(val exception: Throwable) : GetLateRankListUiState
 }

--- a/feature/main/src/main/java/com/goms/main/viewmodel/MainViewModel.kt
+++ b/feature/main/src/main/java/com/goms/main/viewmodel/MainViewModel.kt
@@ -110,7 +110,13 @@ class MainViewModel @Inject constructor(
             .collectLatest { result ->
                 when (result) {
                     is Result.Loading -> _getLateRankListUiState.value = GetLateRankListUiState.Loading
-                    is Result.Success -> _getLateRankListUiState.value = GetLateRankListUiState.Success(result.data)
+                    is Result.Success -> {
+                        if (result.data.isEmpty()) {
+                            _getLateRankListUiState.value = GetLateRankListUiState.Empty
+                        } else {
+                            _getLateRankListUiState.value = GetLateRankListUiState.Success(result.data)
+                        }
+                    }
                     is Result.Error -> _getLateRankListUiState.value = GetLateRankListUiState.Error(result.exception)
                 }
             }


### PR DESCRIPTION
## 📌 개요
- 스켈레톤 로딩 생성 (콘텐츠가 로드되는 동안 비어 있는 틀이 보여지는 것)

## 🔀 변경사항
- 데이터를 가져오는 부분에서 로딩시에 스켈레톤 로딩 적용
- shimmerEffect 생성
- component 나누기

## 📸 구현 화면
[Screen_recording_20240214_185243.webm](https://github.com/team-haribo/GOMS-Android-V2/assets/103114398/69c3490e-7920-4e40-b248-d827f3257005)
