### PR TITLE
🔀 :: (#77) - increase click effect visibility

### DIFF
--- a/core/design-system/src/main/java/com/goms/design_system/component/clickable/gomsClickable.kt
+++ b/core/design-system/src/main/java/com/goms/design_system/component/clickable/gomsClickable.kt
@@ -3,15 +3,18 @@ package com.goms.design_system.component.clickable
 import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.debugInspectorInfo
 import androidx.compose.ui.semantics.Role
 
 fun Modifier.gomsClickable(
     enabled: Boolean = true,
     isIndication: Boolean = false,
+    rippleColor: Color? = null,
     onClickLabel: String? = null,
     role: Role? = null,
     onClick: () -> Unit
@@ -30,7 +33,13 @@ fun Modifier.gomsClickable(
         onClickLabel = onClickLabel,
         onClick = { multipleEventsCutter.processEvent { onClick() } },
         role = role,
-        indication = if (isIndication) LocalIndication.current else null,
+        indication = if (isIndication) {
+            rippleColor?.let {
+                rememberRipple(
+                    color = it
+                )
+            } ?: LocalIndication.current
+        } else null,
         interactionSource = remember { MutableInteractionSource() }
     )
 }

--- a/core/design-system/src/main/java/com/goms/design_system/theme/ColorTheme.kt
+++ b/core/design-system/src/main/java/com/goms/design_system/theme/ColorTheme.kt
@@ -60,4 +60,6 @@ abstract class ColorTheme {
 
     abstract val BLACK: Color
     abstract val WHITE: Color
+
+    abstract val BACKGROUND: Color
 }

--- a/core/design-system/src/main/java/com/goms/design_system/theme/color/DarkColor.kt
+++ b/core/design-system/src/main/java/com/goms/design_system/theme/color/DarkColor.kt
@@ -56,4 +56,6 @@ object DarkColor : ColorTheme() {
 
     override val BLACK = Color(0xFF000000)
     override val WHITE = Color(0xFFFFFFFF)
+
+    override val BACKGROUND = Color(0xFF0D0D0D)
 }

--- a/core/design-system/src/main/java/com/goms/design_system/theme/color/LightColor.kt
+++ b/core/design-system/src/main/java/com/goms/design_system/theme/color/LightColor.kt
@@ -56,4 +56,6 @@ object LightColor : ColorTheme() {
 
     override val BLACK = Color(0xFFFFFFFF)
     override val WHITE = Color(0xFF000000)
+
+    override val BACKGROUND = Color(0xFFFAFAFA)
 }

--- a/core/design-system/src/main/java/com/goms/design_system/util/systemUi.kt
+++ b/core/design-system/src/main/java/com/goms/design_system/util/systemUi.kt
@@ -11,13 +11,11 @@ import androidx.core.view.WindowCompat
 fun ApplySystemUi(isDarkTheme: Boolean) {
     val view = LocalView.current
     val context = view.context as? Activity ?: return
-
-    val statusBarColor = if (isDarkTheme) Color.Black else Color.White
-    val navigationBarColor = if (isDarkTheme) Color.Black else Color.White
+    val color = if (isDarkTheme) Color(0xFF0D0D0D) else Color(0xFFFAFAFA)
 
     WindowCompat.setDecorFitsSystemWindows(context.window, false)
     val insetsController = WindowCompat.getInsetsController(context.window, view)
     insetsController.isAppearanceLightStatusBars = !isDarkTheme
-    context.window.statusBarColor = statusBarColor.toArgb()
-    context.window.navigationBarColor = navigationBarColor.toArgb()
+    context.window.statusBarColor = color.toArgb()
+    context.window.navigationBarColor = color.toArgb()
 }

--- a/core/ui/src/main/java/com/goms/ui/GomsTopBar.kt
+++ b/core/ui/src/main/java/com/goms/ui/GomsTopBar.kt
@@ -1,6 +1,5 @@
 package com.goms.ui
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -8,19 +7,15 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -39,8 +34,6 @@ fun GomsTopBar(
     onSettingClick: () -> Unit,
     onAdminClick: () -> Unit
 ) {
-    var backgroundColor by remember { mutableStateOf(Color.Transparent) }
-
     GomsTheme { colors, typography ->
         Row(
             modifier = modifier
@@ -54,12 +47,12 @@ fun GomsTopBar(
             if (role == Authority.ROLE_STUDENT_COUNCIL) {
                 Box(
                     modifier = Modifier
-                        .clip(RoundedCornerShape(8.dp))
-                        .background(backgroundColor)
-                        .gomsClickable(isIndication = true) {
-                            backgroundColor = colors.G7.copy(0.5f)
+                        .clip(RoundedCornerShape(40.dp))
+                        .gomsClickable(
+                            isIndication = true,
+                            rippleColor = colors.G7.copy(0.5f)
+                        ) {
                             onAdminClick()
-                            backgroundColor = Color.Transparent
                         }
                 ) {
                     Row(
@@ -77,7 +70,18 @@ fun GomsTopBar(
                 }
             }
             Spacer(modifier = Modifier.width(32.dp))
-            IconButton(onClick = { onSettingClick() }) {
+            Box(
+                modifier = Modifier
+                    .size(40.dp)
+                    .clip(CircleShape)
+                    .gomsClickable(
+                        isIndication = true,
+                        rippleColor = colors.G7.copy(0.5f)
+                    ) {
+                        onSettingClick()
+                    },
+                contentAlignment = Alignment.Center
+            ) {
                 icon()
             }
         }

--- a/feature/login/src/main/java/com/goms/login/InputLoginScreen.kt
+++ b/feature/login/src/main/java/com/goms/login/InputLoginScreen.kt
@@ -144,7 +144,7 @@ fun InputLoginScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .background(colors.BLACK)
+                .background(colors.BACKGROUND)
                 .statusBarsPadding()
                 .navigationBarsPadding()
                 .imePadding()

--- a/feature/login/src/main/java/com/goms/login/LoginScreen.kt
+++ b/feature/login/src/main/java/com/goms/login/LoginScreen.kt
@@ -42,7 +42,7 @@ fun LoginScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .background(colors.BLACK)
+                .background(colors.BACKGROUND)
                 .padding(horizontal = 20.dp)
                 .navigationBarsPadding(),
             horizontalAlignment = Alignment.CenterHorizontally

--- a/feature/main/src/main/java/com/goms/main/LateListScreen.kt
+++ b/feature/main/src/main/java/com/goms/main/LateListScreen.kt
@@ -87,7 +87,7 @@ fun LateListScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .background(colors.BLACK)
+                .background(colors.BACKGROUND)
                 .statusBarsPadding()
                 .navigationBarsPadding()
                 .pointerInput(Unit) {

--- a/feature/main/src/main/java/com/goms/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/goms/main/MainScreen.kt
@@ -115,7 +115,7 @@ fun MainScreen(
                 .fillMaxSize()
                 .statusBarsPadding()
                 .navigationBarsPadding()
-                .background(colors.BLACK)
+                .background(colors.BACKGROUND)
         ) {
             Column {
                 GomsTopBar(

--- a/feature/main/src/main/java/com/goms/main/OutingStatusScreen.kt
+++ b/feature/main/src/main/java/com/goms/main/OutingStatusScreen.kt
@@ -118,7 +118,7 @@ fun OutingStatusScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .background(colors.BLACK)
+                .background(colors.BACKGROUND)
                 .statusBarsPadding()
                 .navigationBarsPadding()
                 .pointerInput(Unit) {

--- a/feature/main/src/main/java/com/goms/main/StudentManagementScreen.kt
+++ b/feature/main/src/main/java/com/goms/main/StudentManagementScreen.kt
@@ -168,7 +168,7 @@ fun StudentManagementScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .background(colors.BLACK)
+                .background(colors.BACKGROUND)
                 .statusBarsPadding()
                 .navigationBarsPadding()
                 .pointerInput(Unit) {

--- a/feature/sign-up/src/main/java/com/goms/sign_up/NumberScreen.kt
+++ b/feature/sign-up/src/main/java/com/goms/sign_up/NumberScreen.kt
@@ -114,7 +114,7 @@ fun NumberScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .background(colors.BLACK)
+                .background(colors.BACKGROUND)
                 .statusBarsPadding()
                 .navigationBarsPadding()
                 .imePadding()

--- a/feature/sign-up/src/main/java/com/goms/sign_up/PasswordScreen.kt
+++ b/feature/sign-up/src/main/java/com/goms/sign_up/PasswordScreen.kt
@@ -128,7 +128,7 @@ fun PasswordScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .background(colors.BLACK)
+                .background(colors.BACKGROUND)
                 .statusBarsPadding()
                 .navigationBarsPadding()
                 .imePadding()

--- a/feature/sign-up/src/main/java/com/goms/sign_up/SignUpScreen.kt
+++ b/feature/sign-up/src/main/java/com/goms/sign_up/SignUpScreen.kt
@@ -130,7 +130,7 @@ fun SignUpScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .background(colors.BLACK)
+                .background(colors.BACKGROUND)
                 .statusBarsPadding()
                 .navigationBarsPadding()
                 .pointerInput(Unit) {


### PR DESCRIPTION
## 📌 개요
- 다크모드일때 특정 버튼 클릭 효과가 안보이는 경우가 있어 수정

## 🔀 변경사항
- gomsClickable에 ripple 효과 추가와 ripple color 커스텀 할 수 있게 변경
- screen background color 추가

## 📸 구현 화면
[Screen_recording_20240305_135654.webm](https://github.com/team-haribo/GOMS-Android-V2/assets/103114398/46d89d82-02d9-4a94-9cb0-8f02da4d8345)
