### PR TITLE
🔀 :: (#83) - fix setcontent

### DIFF
--- a/app/src/main/java/com/goms/goms_android_v2/MainActivity.kt
+++ b/app/src/main/java/com/goms/goms_android_v2/MainActivity.kt
@@ -1,7 +1,6 @@
 package com.goms.goms_android_v2
 
 import android.os.Bundle
-import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.compose.setContent
@@ -13,9 +12,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
 import com.goms.common.result.Result
 import com.goms.design_system.theme.GomsTheme
 import com.goms.goms_android_v2.ui.GomsApp
@@ -46,16 +43,14 @@ class MainActivity : ComponentActivity() {
         var uiState: MainActivityUiState by mutableStateOf(MainActivityUiState.Loading)
 
         lifecycleScope.launch {
-            lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.uiState
-                    .onEach { uiState = it }
-                    .collectLatest {
-                        if (it is MainActivityUiState.Success) {
-                            getNotification()
-                            viewModel.setAuthority(authority = it.getProfileResponse.authority.toString())
-                        }
+            viewModel.uiState
+                .onEach { uiState = it }
+                .collectLatest {
+                    if (it is MainActivityUiState.Success) {
+                        getNotification()
+                        viewModel.setAuthority(authority = it.getProfileResponse.authority.toString())
                     }
-            }
+                }
         }
 
         setContent {
@@ -109,6 +104,7 @@ class MainActivity : ComponentActivity() {
                         val deviceTokenSF = getSharedPreferences("deviceToken", MODE_PRIVATE)
                         deviceTokenSF.edit().putString("device", deviceToken).apply()
                     }
+
                     is Result.Error, Result.Loading -> Unit
                 }
             }

--- a/feature/main/src/main/java/com/goms/main/LateListScreen.kt
+++ b/feature/main/src/main/java/com/goms/main/LateListScreen.kt
@@ -67,8 +67,6 @@ fun LateListScreen(
     lateListCallBack: (LocalDate) -> Unit
 ) {
     val scrollState = rememberScrollState()
-    val focusManager = LocalFocusManager.current
-    val isKeyboardOpen by keyboardAsState()
     val datePickerState = rememberDatePickerState()
     var onDatePickerBottomSheetOpenClick by remember { mutableStateOf(false) }
     val selectedDateMillis = datePickerState.selectedDateMillis ?: getDefaultWednesday().toEpochMilliseconds()
@@ -80,12 +78,6 @@ fun LateListScreen(
         lateListCallBack(selectedLocalDate)
     }
 
-    LaunchedEffect(isKeyboardOpen) {
-        if (!isKeyboardOpen) {
-            focusManager.clearFocus()
-        }
-    }
-
     GomsTheme { colors, typography ->
         Column(
             modifier = Modifier
@@ -93,11 +85,6 @@ fun LateListScreen(
                 .background(colors.BACKGROUND)
                 .statusBarsPadding()
                 .navigationBarsPadding()
-                .pointerInput(Unit) {
-                    detectTapGestures {
-                        focusManager.clearFocus()
-                    }
-                }
         ) {
             GomsBackButton {
                 onBackClick()


### PR DESCRIPTION
## 📌 개요
- setcontent 버그 고치기

## 🔀 변경사항
- 앱이 백그라운드에서 포그라운드 상태로 전환될때 setContent가 다시 호출되어서 현재 화면의 데이터를 상실하는 버그 수정

## 📸 구현 화면
[Screen_recording_20240307_111418.webm](https://github.com/team-haribo/GOMS-Android-V2/assets/103114398/3850dcbe-0515-448d-bb1c-c10ce5e4d9f9)
