### PR TITLE
🔀 :: (#95) - apply drop down to sign up

### DIFF
--- a/core/design-system/src/main/java/com/goms/design_system/component/dropdown/GomsDropdown.kt
+++ b/core/design-system/src/main/java/com/goms/design_system/component/dropdown/GomsDropdown.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
@@ -35,6 +36,7 @@ enum class DropdownState(val value: String) {
     Hide("Hide"),
     OnDissmiss("OnDissmiss"),
 }
+
 @Composable
 fun GomsDropdown(
     dropdownList: List<String>,
@@ -107,7 +109,12 @@ fun GomsDropdown(
                                         },
                                     contentAlignment = Alignment.CenterStart
                                 ) {
-                                    Text(text = item)
+                                    Text(
+                                        text = item,
+                                        style = typography.textMedium,
+                                        color = colors.WHITE,
+                                        fontWeight = FontWeight.Normal
+                                    )
                                 }
                             }
                         }

--- a/core/model/src/main/java/com/goms/model/enum/Major.kt
+++ b/core/model/src/main/java/com/goms/model/enum/Major.kt
@@ -1,7 +1,7 @@
 package com.goms.model.enum
 
-enum class Major(val value: String) {
-    SW_DEVELOP("SW"),
-    SMART_IOT("IoT"),
-    AI("AI")
+enum class Major(val value: String, val fullName: String) {
+    SW_DEVELOP("SW", "SW개발과"),
+    SMART_IOT("IoT", "스마트IoT과"),
+    AI("AI", "AI개발과")
 }

--- a/feature/setting/src/main/java/com/goms/setting/component/SelectThemeDropDown.kt
+++ b/feature/setting/src/main/java/com/goms/setting/component/SelectThemeDropDown.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -40,6 +41,12 @@ fun SelectThemeDropDown(
     var dropdownState by remember { mutableStateOf(DropdownState.Hide.name) }
     val dropdownList = listOf("다크(기본)","라이트","시스템 테마 설정")
     var selectedIndex by rememberSaveable { mutableIntStateOf(0) }
+
+    val derivedDropdownState = remember(dropdownState) {
+        derivedStateOf {
+            dropdownState
+        }
+    }
 
     LaunchedEffect(dropdownState) {
         if (dropdownState == DropdownState.OnDissmiss.name) {
@@ -73,10 +80,9 @@ fun SelectThemeDropDown(
                     .background(colors.G1)
                     .padding(12.dp)
                     .gomsClickable {
-                        dropdownState = when (dropdownState) {
-                            DropdownState.Show.name -> DropdownState.Hide.name
-                            DropdownState.Hide.name -> DropdownState.Show.name
-                            else -> dropdownState
+                        when (dropdownState) {
+                            DropdownState.Show.name -> dropdownState = DropdownState.Hide.name
+                            DropdownState.Hide.name -> dropdownState = DropdownState.Show.name
                         }
                     },
                 horizontalArrangement = Arrangement.SpaceBetween,
@@ -102,7 +108,7 @@ fun SelectThemeDropDown(
             GomsDropdown(
                 dropdownList = dropdownList,
                 dropdownListSize = dropdownList.size,
-                showDropdown = dropdownState,
+                showDropdown = derivedDropdownState.value,
                 selectedIndex = selectedIndex,
                 modifier = Modifier.padding(horizontal = 20.dp),
                 backgroundColor = colors.G1,
@@ -112,7 +118,6 @@ fun SelectThemeDropDown(
                     dropdownState = DropdownState.Hide.name
                 }
             )
-
         }
     }
 }

--- a/feature/setting/src/main/java/com/goms/setting/component/SettingProfileCard.kt
+++ b/feature/setting/src/main/java/com/goms/setting/component/SettingProfileCard.kt
@@ -60,7 +60,8 @@ fun SettingProfileCardComponent(
 ) {
     GomsTheme { colors, typography ->
         Row(
-            modifier = modifier.fillMaxWidth()
+            modifier = modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
         ) {
             Box(
                 contentAlignment = Alignment.BottomEnd
@@ -98,13 +99,13 @@ fun SettingProfileCardComponent(
             Column {
                 Text(
                     text = data.name,
-                    style = typography.textMedium,
+                    style = typography.titleSmall,
                     color = colors.WHITE,
                     fontWeight = FontWeight.SemiBold
                 )
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
-                    text = data.grade.toString() + "기 | " + data.major.toText(),
+                    text = "${data.grade}기 | ${data.major.toText()}",
                     style = typography.textMedium,
                     color = colors.G4,
                     fontWeight = FontWeight.Normal

--- a/feature/sign-up/src/main/java/com/goms/sign_up/PasswordScreen.kt
+++ b/feature/sign-up/src/main/java/com/goms/sign_up/PasswordScreen.kt
@@ -73,7 +73,7 @@ fun PasswordRoute(
                         password = viewModel.password.value,
                         name = viewModel.name.value,
                         gender = Gender.values().find { it.value == viewModel.gender.value }!!.name,
-                        major = Major.values().find { it.value == viewModel.major.value }!!.name
+                        major = Major.values().find { it.fullName == viewModel.major.value }!!.name
                     )
                 )
             }

--- a/feature/sign-up/src/main/java/com/goms/sign_up/SignUpScreen.kt
+++ b/feature/sign-up/src/main/java/com/goms/sign_up/SignUpScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -30,19 +29,17 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.goms.common.result.Result
-import com.goms.design_system.component.bottomsheet.SelectorBottomSheet
 import com.goms.design_system.component.button.ButtonState
 import com.goms.design_system.component.button.GomsBackButton
 import com.goms.design_system.component.button.GomsButton
 import com.goms.design_system.component.indicator.GomsCircularProgressIndicator
-import com.goms.design_system.component.textfield.GomsBottomSheetTextField
 import com.goms.design_system.component.textfield.GomsTextField
 import com.goms.design_system.theme.GomsTheme
 import com.goms.design_system.util.keyboardAsState
 import com.goms.design_system.util.lockScreenOrientation
-import com.goms.model.enum.Gender
-import com.goms.model.enum.Major
 import com.goms.model.request.auth.SendNumberRequest
+import com.goms.sign_up.component.SelectGenderDropDown
+import com.goms.sign_up.component.SelectMajorDropDown
 import com.goms.sign_up.component.SignUpText
 import com.goms.sign_up.viewmodel.SignUpViewModelProvider
 import com.goms.ui.isStrongEmail
@@ -100,8 +97,6 @@ fun SignUpScreen(
 ) {
     val focusManager = LocalFocusManager.current
     val isKeyboardOpen by keyboardAsState()
-    var onGenderBottomSheetOpenClick by rememberSaveable { mutableStateOf(false) }
-    var onMajorBottomSheetOpenClick by rememberSaveable { mutableStateOf(false) }
     var isLoading by remember { mutableStateOf(false) }
 
     LaunchedEffect(isKeyboardOpen) {
@@ -162,28 +157,19 @@ fun SignUpScreen(
                     onValueChange = onEmailChange,
                     singleLine = true
                 )
-                GomsBottomSheetTextField(
-                    modifier = Modifier.fillMaxWidth(),
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
-                    placeHolder = "성별",
-                    setText = gender,
-                    onValueChange = onGenderChange,
-                    readOnly = true,
-                    singleLine = true
+                SelectGenderDropDown(
+                    modifier = Modifier,
+                    gender = gender,
+                    onSelectGender = onGenderChange
                 ) {
-                    onGenderBottomSheetOpenClick = true
                     focusManager.clearFocus()
                 }
-                GomsBottomSheetTextField(
-                    modifier = Modifier.fillMaxWidth(),
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
-                    placeHolder = "과",
-                    setText = major,
-                    onValueChange = onMajorChange,
-                    readOnly = true,
-                    singleLine = true
+                Spacer(modifier = Modifier.height(30.dp))
+                SelectMajorDropDown(
+                    modifier = Modifier,
+                    major = major,
+                    onSelectMajor = onMajorChange
                 ) {
-                    onMajorBottomSheetOpenClick = true
                     focusManager.clearFocus()
                 }
                 Spacer(modifier = Modifier.weight(1f))
@@ -203,30 +189,6 @@ fun SignUpScreen(
                 }
                 Spacer(modifier = Modifier.height(100.dp))
             }
-        }
-        if (onGenderBottomSheetOpenClick) {
-            SelectorBottomSheet(
-                modifier = Modifier.fillMaxWidth(),
-                title = "성별",
-                list = listOf(Gender.MAN.value, Gender.WOMAN.value),
-                selected = gender,
-                itemChange = onGenderChange,
-                closeSheet = {
-                    onGenderBottomSheetOpenClick = false
-                }
-            )
-        }
-        if (onMajorBottomSheetOpenClick) {
-            SelectorBottomSheet(
-                modifier = Modifier.fillMaxWidth(),
-                title = "과",
-                list = listOf(Major.SW_DEVELOP.value, Major.SMART_IOT.value, Major.AI.value),
-                selected = major,
-                itemChange = onMajorChange,
-                closeSheet = {
-                    onMajorBottomSheetOpenClick = false
-                }
-            )
         }
         if (isLoading) {
             GomsCircularProgressIndicator()

--- a/feature/sign-up/src/main/java/com/goms/sign_up/component/SelectGenderDropDown.kt
+++ b/feature/sign-up/src/main/java/com/goms/sign_up/component/SelectGenderDropDown.kt
@@ -1,0 +1,115 @@
+package com.goms.sign_up.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.goms.design_system.component.clickable.gomsClickable
+import com.goms.design_system.component.dropdown.DropdownState
+import com.goms.design_system.component.dropdown.GomsDropdown
+import com.goms.design_system.icon.ChevronDownIcon
+import com.goms.design_system.icon.ChevronUpIcon
+import com.goms.design_system.theme.GomsTheme
+import com.goms.model.enum.Gender
+import androidx.compose.runtime.derivedStateOf
+
+@Composable
+fun SelectGenderDropDown(
+    modifier: Modifier,
+    gender: String,
+    onSelectGender: (String) -> Unit,
+    onClick: () -> Unit
+) {
+    var dropdownState by remember { mutableStateOf(DropdownState.Hide.name) }
+    val dropdownList = listOf(Gender.MAN.value, Gender.WOMAN.value)
+    var selectedIndex by rememberSaveable { mutableIntStateOf(0) }
+
+    val derivedDropdownState = remember(dropdownState) {
+        derivedStateOf {
+            dropdownState
+        }
+    }
+
+    LaunchedEffect(dropdownState) {
+        if (dropdownState == DropdownState.OnDissmiss.name) {
+            dropdownState = DropdownState.Hide.name
+        }
+    }
+
+    GomsTheme { colors, typography ->
+        Row(
+            modifier = modifier
+                .fillMaxWidth()
+                .height(64.dp)
+                .clip(RoundedCornerShape(12.dp))
+                .background(colors.G1)
+                .border(
+                    width = 1.dp,
+                    color = colors.WHITE.copy(0.15f),
+                    shape = RoundedCornerShape(12.dp)
+                )
+                .padding(12.dp)
+                .gomsClickable {
+                    when (dropdownState) {
+                        DropdownState.Show.name -> dropdownState = DropdownState.Hide.name
+                        DropdownState.Hide.name -> dropdownState = DropdownState.Show.name
+                    }
+                    onClick()
+                },
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = gender.ifBlank { "성별" },
+                style = typography.textMedium,
+                color = if (gender.isNotBlank()) colors.WHITE else colors.G7,
+                fontWeight = FontWeight.Normal
+            )
+            if (derivedDropdownState.value == DropdownState.Show.name) {
+                ChevronDownIcon(
+                    tint = colors.G7
+                )
+            } else {
+                ChevronUpIcon(
+                    tint = colors.WHITE
+                )
+            }
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        GomsDropdown(
+            dropdownList = dropdownList,
+            dropdownListSize = dropdownList.size,
+            showDropdown = derivedDropdownState.value,
+            selectedIndex = selectedIndex,
+            modifier = Modifier.padding(horizontal = 20.dp),
+            backgroundColor = colors.G1,
+            onDissmiss = {
+                dropdownState = DropdownState.OnDissmiss.name
+            },
+            onItemClick = {
+                selectedIndex = it
+                dropdownState = DropdownState.Hide.name
+                onSelectGender(dropdownList[selectedIndex])
+            }
+        )
+    }
+}

--- a/feature/sign-up/src/main/java/com/goms/sign_up/component/SelectMajorDropDown.kt
+++ b/feature/sign-up/src/main/java/com/goms/sign_up/component/SelectMajorDropDown.kt
@@ -1,0 +1,115 @@
+package com.goms.sign_up.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.goms.design_system.component.clickable.gomsClickable
+import com.goms.design_system.component.dropdown.DropdownState
+import com.goms.design_system.component.dropdown.GomsDropdown
+import com.goms.design_system.icon.ChevronDownIcon
+import com.goms.design_system.icon.ChevronUpIcon
+import com.goms.design_system.theme.GomsTheme
+import com.goms.model.enum.Major
+
+@Composable
+fun SelectMajorDropDown(
+    modifier: Modifier,
+    major: String,
+    onSelectMajor: (String) -> Unit,
+    onClick: () -> Unit
+) {
+    var dropdownState by remember { mutableStateOf(DropdownState.Hide.name) }
+    val dropdownList = listOf(Major.SW_DEVELOP.fullName, Major.SMART_IOT.fullName, Major.AI.fullName)
+    var selectedIndex by rememberSaveable { mutableIntStateOf(0) }
+
+    val derivedDropdownState = remember(dropdownState) {
+        derivedStateOf {
+            dropdownState
+        }
+    }
+
+    LaunchedEffect(dropdownState) {
+        if (dropdownState == DropdownState.OnDissmiss.name) {
+            dropdownState = DropdownState.Hide.name
+        }
+    }
+
+    GomsTheme { colors, typography ->
+        Row(
+            modifier = modifier
+                .fillMaxWidth()
+                .height(64.dp)
+                .clip(RoundedCornerShape(12.dp))
+                .background(colors.G1)
+                .border(
+                    width = 1.dp,
+                    color = colors.WHITE.copy(0.15f),
+                    shape = RoundedCornerShape(12.dp)
+                )
+                .padding(12.dp)
+                .gomsClickable {
+                    when (dropdownState) {
+                        DropdownState.Show.name -> dropdownState = DropdownState.Hide.name
+                        DropdownState.Hide.name -> dropdownState = DropdownState.Show.name
+                    }
+                    onClick()
+                },
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = major.ifBlank { "학과" },
+                style = typography.textMedium,
+                color = if (major.isNotBlank()) colors.WHITE else colors.G7,
+                fontWeight = FontWeight.Normal
+            )
+            if (derivedDropdownState.value == DropdownState.Show.name) {
+                ChevronDownIcon(
+                    tint = colors.G7
+                )
+            } else {
+                ChevronUpIcon(
+                    tint = colors.WHITE
+                )
+            }
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        GomsDropdown(
+            dropdownList = dropdownList,
+            dropdownListSize = dropdownList.size,
+            showDropdown = derivedDropdownState.value,
+            selectedIndex = selectedIndex,
+            modifier = Modifier.padding(horizontal = 20.dp),
+            backgroundColor = colors.G1,
+            onDissmiss = {
+                dropdownState = DropdownState.OnDissmiss.name
+            },
+            onItemClick = {
+                selectedIndex = it
+                dropdownState = DropdownState.Hide.name
+                onSelectMajor(dropdownList[selectedIndex])
+            }
+        )
+    }
+}


### PR DESCRIPTION
## 📌 개요
- 회원가입에 드롭다운 적용

## 🔀 변경사항
- 드롭다운을 다시 눌러서 닫았을때 onDissmiss가 호출, Hide 상태가 중첩되어 드롭다운이 다시 열리는 문제를 derivedStateOf를 사용하여 해결
- Major에 pull name 추가
- 회원가입에서 바텀 시트를 드롭다운으로 변경

## 📸 구현 화면
[Screen_recording_20240312_120857.webm](https://github.com/team-haribo/GOMS-Android-V2/assets/103114398/489ebc8e-408b-4c91-acef-d643240f8266)

