### PR TITLE
🔀 :: (#120) - reflect the changes in the auth part design

### DIFF
--- a/app/src/main/java/com/goms/goms_android_v2/navigation/GomsNavHost.kt
+++ b/app/src/main/java/com/goms/goms_android_v2/navigation/GomsNavHost.kt
@@ -81,7 +81,7 @@ fun GomsNavHost(
         inputLoginScreen(
             onBackClick = navController::popBackStack,
             onMainClick = { appState.navigateToTopLevelDestination(TopLevelDestination.MAIN) },
-            onRePasswordClick = navController::navigateToRePassword,
+            onRePasswordClick = navController::navigateToEmailCheck,
             onErrorToast = onErrorToast
         )
         signUpScreen(

--- a/app/src/main/java/com/goms/goms_android_v2/navigation/GomsNavHost.kt
+++ b/app/src/main/java/com/goms/goms_android_v2/navigation/GomsNavHost.kt
@@ -153,7 +153,8 @@ fun GomsNavHost(
         )
         passwordNumberScreen(
             onBackClick = navController::popBackStack,
-            onRePasswordClick = navController::navigateToRePassword
+            onRePasswordClick = navController::navigateToRePassword,
+            onErrorToast = onErrorToast
         )
         rePasswordScreen(
             onBackClick = navController::popBackStack,

--- a/app/src/main/java/com/goms/goms_android_v2/navigation/GomsNavHost.kt
+++ b/app/src/main/java/com/goms/goms_android_v2/navigation/GomsNavHost.kt
@@ -81,6 +81,7 @@ fun GomsNavHost(
         inputLoginScreen(
             onBackClick = navController::popBackStack,
             onMainClick = { appState.navigateToTopLevelDestination(TopLevelDestination.MAIN) },
+            onRePasswordClick = navController::navigateToRePassword,
             onErrorToast = onErrorToast
         )
         signUpScreen(

--- a/core/design-system/src/main/java/com/goms/design_system/component/button/GomsBackButton.kt
+++ b/core/design-system/src/main/java/com/goms/design_system/component/button/GomsBackButton.kt
@@ -28,13 +28,13 @@ fun GomsBackButton(
             .gomsClickable { onClick() },
         verticalAlignment = Alignment.CenterVertically
     ) {
-        BackIcon()
+        BackIcon(tint = colors.P5)
         Spacer(modifier = Modifier.width(7.dp))
         Text(
             text = "돌아가기",
             style = typography.textMedium,
             fontWeight = FontWeight.Normal,
-            color = colors.I5
+            color = colors.P5
         )
     }
 }

--- a/core/design-system/src/main/java/com/goms/design_system/component/dropdown/GomsDropdown.kt
+++ b/core/design-system/src/main/java/com/goms/design_system/component/dropdown/GomsDropdown.kt
@@ -66,7 +66,7 @@ fun GomsDropdown(
                 .border(
                     BorderStroke(
                         width = 1.dp,
-                        color = colors.WHITE.copy(0.15f)
+                        color = if (showDropdown == true) colors.WHITE.copy(0.15f) else Color.Transparent
                     ),
                     shape = RoundedCornerShape(12.dp)
                 )

--- a/core/design-system/src/main/java/com/goms/design_system/component/text/LinkText.kt
+++ b/core/design-system/src/main/java/com/goms/design_system/component/text/LinkText.kt
@@ -63,7 +63,7 @@ fun LinkText(
                 text = text,
                 style = typography.buttonLarge,
                 fontWeight = FontWeight.Normal,
-                color = colors.I5
+                color = colors.P5
             )
         }
     }

--- a/core/design-system/src/main/java/com/goms/design_system/component/text/RowLinkText.kt
+++ b/core/design-system/src/main/java/com/goms/design_system/component/text/RowLinkText.kt
@@ -1,0 +1,45 @@
+package com.goms.design_system.component.text
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Divider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.goms.design_system.component.clickable.gomsClickable
+import com.goms.design_system.theme.GomsTheme
+import com.goms.design_system.theme.GomsTheme.colors
+import com.goms.design_system.theme.GomsTheme.typography
+
+@Composable
+fun RowLinkText(
+    onLinkTextClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = "비밀번호를 잊으셨나요?",
+            style = typography.buttonLarge,
+            fontWeight = FontWeight.Normal,
+            color = colors.G4
+        )
+        Text(
+            modifier = Modifier.gomsClickable { onLinkTextClick() },
+            text = "비밀번호 찾기",
+            style = typography.buttonLarge,
+            fontWeight = FontWeight.Normal,
+            color = colors.P5
+        )
+    }
+}

--- a/core/design-system/src/main/java/com/goms/design_system/component/textfield/GomsTextField.kt
+++ b/core/design-system/src/main/java/com/goms/design_system/component/textfield/GomsTextField.kt
@@ -42,7 +42,6 @@ import androidx.compose.ui.unit.dp
 import com.goms.design_system.component.clickable.gomsClickable
 import com.goms.design_system.component.timer.CountdownTimer
 import com.goms.design_system.icon.SearchIcon
-import com.goms.design_system.theme.GomsTheme
 import com.goms.design_system.theme.GomsTheme.colors
 import com.goms.design_system.theme.GomsTheme.typography
 import kotlinx.coroutines.delay
@@ -56,7 +55,6 @@ fun GomsTextField(
     readOnly: Boolean = false,
     focusManager: FocusManager = LocalFocusManager.current,
     focusRequester: FocusRequester = FocusRequester(),
-    errorText: String = "",
     setText: String,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
     keyboardActions: KeyboardActions = KeyboardActions.Default,
@@ -129,20 +127,6 @@ fun GomsTextField(
             readOnly = readOnly,
             visualTransformation = visualTransformation
         )
-        Column(
-            modifier = Modifier
-                .height(32.dp)
-                .padding(start = 8.dp),
-            verticalArrangement = Arrangement.Center
-        ) {
-            if (isError) {
-                Text(
-                    text = errorText,
-                    color = colors.N5,
-                    style = typography.buttonLarge
-                )
-            }
-        }
     }
 }
 
@@ -533,7 +517,6 @@ fun GomsTextFieldPreview() {
             modifier = Modifier.fillMaxWidth(),
             placeHolder = "Test",
             isError = true,
-            errorText = "오류",
             onValueChange = {},
             setText = ""
         )

--- a/core/design-system/src/main/java/com/goms/design_system/component/textfield/GomsTextField.kt
+++ b/core/design-system/src/main/java/com/goms/design_system/component/textfield/GomsTextField.kt
@@ -132,12 +132,17 @@ fun GomsTextField(
 
 @Composable
 fun NumberTextField(
-    text: String,
+    modifier: Modifier = Modifier,
+    setText: String,
+    placeHolder: String = "",
+    focusManager: FocusManager = LocalFocusManager.current,
+    focusRequester: FocusRequester = FocusRequester(),
     isError: Boolean,
     errorText: String = "",
     onValueChange: (String) -> Unit,
     onResendClick: () -> Unit,
 ) {
+    val isFocused = remember { mutableStateOf(false) }
     val isErrorTextField = remember { mutableStateOf(isError) }
     val errorTextTextField = remember { mutableStateOf(errorText) }
 
@@ -146,184 +151,71 @@ fun NumberTextField(
         errorTextTextField.value = errorText
     }
 
-    Column {
-        BasicTextField(
-            value = text.take(4),
-            onValueChange = {
-                if (it.length <= 4) {
-                    onValueChange(it)
-                }
-            },
-            keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Number),
-            decorationBox = {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween
-                ) {
-                    text.forEachIndexed { index, char ->
-                        NumberTextFieldCharContainer(
-                            modifier = Modifier,
-                            text = char,
-                            isError = isErrorTextField.value
-                        )
-                    }
-                    repeat(4 - text.length) {
-                        NumberTextFieldCharContainer(
-                            modifier = Modifier,
-                            text = ' ',
-                            isError = isErrorTextField.value
-                        )
-                    }
-                }
-            },
-            singleLine = true
-        )
-        CountdownTimer(
-            isError = isErrorTextField.value,
-            errorText = errorTextTextField.value,
-            onTimerFinish = {
-                isErrorTextField.value = true
-                errorTextTextField.value = "시간이 만료되었습니다"
-            },
-            onTimerReset = {
-                isErrorTextField.value = false
-                errorTextTextField.value = ""
-                onResendClick()
-            }
-        )
-    }
-}
-
-
-@Composable
-private fun NumberTextFieldCharContainer(
-    modifier: Modifier,
-    text: Char,
-    isError: Boolean,
-) {
-    val shape = remember { RoundedCornerShape(12.dp) }
-
-    Box(
-        modifier = modifier
-            .size(
-                width = 74.dp,
-                height = 64.dp,
-            )
-            .background(
-                color = colors.G1,
-                shape = shape,
-            )
-            .border(
-                width = 1.dp,
-                color = if (isError) colors.N5 else colors.WHITE.copy(0.15f),
-                shape = shape
-            ),
-        contentAlignment = Alignment.Center,
-    ) {
-        Text(
-            text = text.toString(),
-            color = colors.WHITE,
-            style = typography.titleSmall,
-            fontWeight = FontWeight.SemiBold,
-            textAlign = TextAlign.Center
-        )
-    }
-}
-
-@Composable
-fun GomsBottomSheetTextField(
-    modifier: Modifier = Modifier,
-    isError: Boolean = false,
-    placeHolder: String = "",
-    readOnly: Boolean = false,
-    focusManager: FocusManager = LocalFocusManager.current,
-    focusRequester: FocusRequester = FocusRequester(),
-    errorText: String = "",
-    setText: String,
-    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
-    keyboardActions: KeyboardActions = KeyboardActions.Default,
-    maxLines: Int = Int.MAX_VALUE,
-    singleLine: Boolean = false,
-    visualTransformation: VisualTransformation = VisualTransformation.None,
-    onValueChange: (String) -> Unit = {},
-    onClick: () -> Unit
-) {
-    val isFocused = remember { mutableStateOf(false) }
-
     DisposableEffect(Unit) {
         onDispose {
             focusManager.clearFocus()
         }
     }
 
-    Box(modifier = modifier) {
-        Column {
-            OutlinedTextField(
-                value = setText,
-                onValueChange = {
-                    onValueChange(it)
-                },
-                keyboardOptions = keyboardOptions,
-                keyboardActions = keyboardActions,
-                placeholder = {
-                    Text(
-                        text = placeHolder,
-                        style = typography.textMedium,
-                        fontWeight = FontWeight.Normal,
-                        color = if (isError) colors.N5 else colors.G4
-                    )
-                },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(64.dp)
-                    .focusRequester(focusRequester)
-                    .clip(RoundedCornerShape(12.dp))
-                    .background(colors.G1)
-                    .border(
-                        width = 1.dp,
-                        color = if (isError) colors.N5 else colors.WHITE.copy(0.15f),
-                        shape = RoundedCornerShape(12.dp)
-                    )
-                    .onFocusChanged {
-                        isFocused.value = it.isFocused
-                    },
-                maxLines = maxLines,
-                singleLine = singleLine,
-                textStyle = typography.textMedium,
-                colors = OutlinedTextFieldDefaults.colors(
-                    focusedTextColor = if (isError) colors.N5 else colors.WHITE,
-                    unfocusedTextColor = if (isError) colors.N5 else colors.WHITE,
-                    focusedPlaceholderColor = if (isError) colors.N5 else colors.G4,
-                    unfocusedPlaceholderColor = if (isError) colors.N5 else colors.G4,
-                    focusedBorderColor = Color.Transparent,
-                    unfocusedBorderColor = Color.Transparent,
-                    cursorColor = colors.I5
-                ),
-                readOnly = readOnly,
-                visualTransformation = visualTransformation
-            )
-            Column(
-                modifier = Modifier
-                    .height(32.dp)
-                    .padding(start = 8.dp),
-                verticalArrangement = Arrangement.Center
-            ) {
-                if (isError) {
-                    Text(
-                        text = errorText,
-                        color = colors.N5,
-                        style = typography.buttonLarge
-                    )
-                }
-            }
-        }
-        Box(
-            modifier = Modifier
+    Column {
+        OutlinedTextField(
+            value = setText,
+            onValueChange = {
+                onValueChange(it)
+            },
+            keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Number),
+            placeholder = {
+                Text(
+                    text = placeHolder,
+                    style = typography.textMedium,
+                    fontWeight = FontWeight.Normal,
+                    color = if (isError) colors.N5 else colors.G4
+                )
+            },
+            modifier = modifier
                 .fillMaxWidth()
                 .height(64.dp)
-                .gomsClickable { onClick() }
+                .focusRequester(focusRequester)
+                .clip(RoundedCornerShape(12.dp))
+                .background(colors.G1)
+                .border(
+                    width = 1.dp,
+                    color = if (isError) colors.N5 else Color.Transparent,
+                    shape = RoundedCornerShape(12.dp)
+                )
+                .onFocusChanged {
+                    isFocused.value = it.isFocused
+                    if (it.isFocused) {
+                        onValueChange("")
+                    }
+                },
+            maxLines = 1,
+            singleLine = true,
+            textStyle = typography.textMedium,
+            colors = OutlinedTextFieldDefaults.colors(
+                focusedTextColor = if (isError) colors.N5 else colors.WHITE,
+                unfocusedTextColor = if (isError) colors.N5 else colors.WHITE,
+                focusedPlaceholderColor = if (isError) colors.N5 else colors.G4,
+                unfocusedPlaceholderColor = if (isError) colors.N5 else colors.G4,
+                focusedBorderColor = Color.Transparent,
+                unfocusedBorderColor = Color.Transparent,
+                cursorColor = colors.I5
+            )
         )
     }
+    CountdownTimer(
+        isError = isErrorTextField.value,
+        errorText = errorTextTextField.value,
+        onTimerFinish = {
+            isErrorTextField.value = true
+            errorTextTextField.value = "시간이 만료되었습니다"
+        },
+        onTimerReset = {
+            isErrorTextField.value = false
+            errorTextTextField.value = ""
+            onResendClick()
+        }
+    )
 }
 
 @Composable
@@ -375,7 +267,7 @@ fun GomsPasswordTextField(
                 .background(colors.G1)
                 .border(
                     width = 1.dp,
-                    color = if (isError) colors.N5 else colors.WHITE.copy(0.15f),
+                    color = if (isError) colors.N5 else Color.Transparent,
                     shape = RoundedCornerShape(12.dp)
                 )
                 .onFocusChanged {
@@ -398,13 +290,13 @@ fun GomsPasswordTextField(
         )
         Column(
             modifier = Modifier
-                .heightIn(min = 25.dp)
-                .padding(start = 8.dp),
+                .heightIn(min = 24.dp)
+                .padding(start = 8.dp, top = 4.dp),
             verticalArrangement = Arrangement.Center
         ) {
             if (isDescription) {
                 Text(
-                    text = "대/소문자, 특수문자 6~15자",
+                    text = "·  대/소문자, 특수문자 6~15자",
                     color = colors.G4,
                     style = typography.buttonLarge
                 )
@@ -521,17 +413,18 @@ fun GomsTextFieldPreview() {
             setText = ""
         )
         NumberTextField(
-            text = "1234",
-            isError = false,
-            onValueChange = {},
-            onResendClick = {},
-        )
-        NumberTextField(
-            text = "1234",
+            modifier = Modifier.fillMaxWidth(),
+            placeHolder = "Test",
             isError = true,
-            errorText = "오류",
             onValueChange = {},
-            onResendClick = {},
-        )
+            setText = ""
+        ) {}
+        NumberTextField(
+            modifier = Modifier.fillMaxWidth(),
+            placeHolder = "Test",
+            isError = true,
+            onValueChange = {},
+            setText = ""
+        ) {}
     }
 }

--- a/core/design-system/src/main/java/com/goms/design_system/component/textfield/GomsTextField.kt
+++ b/core/design-system/src/main/java/com/goms/design_system/component/textfield/GomsTextField.kt
@@ -97,7 +97,7 @@ fun GomsTextField(
                 .background(colors.G1)
                 .border(
                     width = 1.dp,
-                    color = if (isError) colors.N5 else colors.WHITE.copy(0.15f),
+                    color = if (isError) colors.N5 else Color.Transparent,
                     shape = RoundedCornerShape(12.dp)
                 )
                 .onFocusChanged {

--- a/core/design-system/src/main/java/com/goms/design_system/component/timer/CountdownTimer.kt
+++ b/core/design-system/src/main/java/com/goms/design_system/component/timer/CountdownTimer.kt
@@ -67,7 +67,7 @@ fun CountdownTimer(
                 onTimerReset()
             },
             text = "재발송",
-            color = colors.I5,
+            color = colors.P5,
             style = typography.buttonLarge
         )
     }

--- a/core/design-system/src/main/java/com/goms/design_system/icon/GomsIcon.kt
+++ b/core/design-system/src/main/java/com/goms/design_system/icon/GomsIcon.kt
@@ -46,11 +46,13 @@ fun GAuthIcon(
 @Composable
 fun BackIcon(
     modifier: Modifier = Modifier,
+    tint: Color = Color.Unspecified
 ) {
     Image(
         painter = painterResource(id = R.drawable.ic_back),
         contentDescription = "Back Icon",
-        modifier = modifier
+        modifier = modifier,
+        colorFilter = if (tint != Color.Unspecified) ColorFilter.tint(tint) else null
     )
 }
 

--- a/core/network/src/main/java/com/goms/network/util/AuthInterceptor.kt
+++ b/core/network/src/main/java/com/goms/network/util/AuthInterceptor.kt
@@ -23,13 +23,14 @@ class AuthInterceptor @Inject constructor(
         val builder = request.newBuilder()
         val currentTime = System.currentTimeMillis().toGomsTimeDate()
         val ignorePath = "/auth"
+        val ignorePath2 = "new-password"
         val ignoreMethodPost = "POST"
         val ignoreMethodGet = "GET"
         val ignoreMethodDELETE = "DELETE"
         val path = request.url.encodedPath
         val method = request.method
 
-        if (path.contains(ignorePath) && (method == ignoreMethodPost || method == ignoreMethodGet)) {
+        if (path.contains(ignorePath) && (method == ignoreMethodPost || method == ignoreMethodGet) || path.contains(ignorePath2)) {
             val response = chain.proceed(request)
             return if (response.code == 204) {
                 response.newBuilder().code(200).build()

--- a/feature/login/src/main/java/com/goms/login/InputLoginScreen.kt
+++ b/feature/login/src/main/java/com/goms/login/InputLoginScreen.kt
@@ -4,6 +4,7 @@ import android.content.pm.ActivityInfo
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -34,6 +35,7 @@ import com.goms.design_system.component.button.ButtonState
 import com.goms.design_system.component.button.GomsBackButton
 import com.goms.design_system.component.button.GomsButton
 import com.goms.design_system.component.indicator.GomsCircularProgressIndicator
+import com.goms.design_system.component.text.RowLinkText
 import com.goms.design_system.component.textfield.GomsTextField
 import com.goms.design_system.theme.GomsTheme.colors
 import com.goms.design_system.util.keyboardAsState
@@ -49,6 +51,7 @@ import com.goms.ui.isStrongEmail
 fun InputLoginRoute(
     onBackClick: () -> Unit,
     onMainClick: () -> Unit,
+    onRePasswordClick: () -> Unit,
     onErrorToast: (throwable: Throwable?, message: String?) -> Unit,
     viewModel: LoginViewModel = hiltViewModel(),
 ) {
@@ -66,6 +69,7 @@ fun InputLoginRoute(
         saveTokenUiState = saveTokenUiState,
         onBackClick = onBackClick,
         onMainClick = onMainClick,
+        onRePasswordClick = onRePasswordClick,
         onErrorToast = onErrorToast,
         loginCallBack = {
             viewModel.login(
@@ -88,6 +92,7 @@ fun InputLoginScreen(
     saveTokenUiState: SaveTokenUiState,
     onBackClick: () -> Unit,
     onMainClick: () -> Unit,
+    onRePasswordClick: () -> Unit,
     onErrorToast: (throwable: Throwable?, message: String?) -> Unit,
     loginCallBack: () -> Unit
 ) {
@@ -96,7 +101,6 @@ fun InputLoginScreen(
     val animatedSpacerHeight by animateDpAsState(targetValue = if (!isKeyboardOpen) 100.dp else 16.dp)
     var isLoading by remember { mutableStateOf(false) }
     var isError by remember { mutableStateOf(false) }
-    var errorText by remember { mutableStateOf("") }
 
     LaunchedEffect(isKeyboardOpen) {
         if (!isKeyboardOpen) {
@@ -122,14 +126,12 @@ fun InputLoginScreen(
             is LoginUiState.BadRequest -> {
                 isLoading = false
                 isError = true
-                errorText = "비밀번호가 일치하지 않습니다"
                 onErrorToast(null, "비밀번호가 일치하지 않습니다")
             }
 
             is LoginUiState.NotFound -> {
                 isLoading = false
                 isError = true
-                errorText = "해당 유저가 존재하지 않습니다"
                 onErrorToast(null, "해당 유저가 존재하지 않습니다")
             }
 
@@ -161,10 +163,10 @@ fun InputLoginScreen(
         }
         Column(
             modifier = Modifier.padding(horizontal = 20.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
+            horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             InputLoginText(modifier = Modifier.align(Alignment.Start))
-            Spacer(modifier = Modifier.weight(1.1f))
+            Spacer(modifier = Modifier.height(28.dp))
             GomsTextField(
                 modifier = Modifier.fillMaxWidth(),
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
@@ -174,6 +176,7 @@ fun InputLoginScreen(
                 isError = isError,
                 singleLine = true
             )
+            Spacer(modifier = Modifier.height(24.dp))
             GomsTextField(
                 modifier = Modifier.fillMaxWidth(),
                 isEmail = false,
@@ -182,10 +185,13 @@ fun InputLoginScreen(
                 setText = password,
                 onValueChange = onPasswordChange,
                 isError = isError,
-                errorText = errorText,
                 singleLine = true,
                 visualTransformation = PasswordVisualTransformation()
             )
+            Spacer(modifier = Modifier.height(8.dp))
+            RowLinkText {
+                onRePasswordClick()
+            }
             Spacer(modifier = Modifier.weight(1f))
             GomsButton(
                 modifier = Modifier.fillMaxWidth(),

--- a/feature/login/src/main/java/com/goms/login/navigation/LoginNavigation.kt
+++ b/feature/login/src/main/java/com/goms/login/navigation/LoginNavigation.kt
@@ -16,7 +16,7 @@ fun NavController.navigateToLogin(navOptions: NavOptions? = null) {
 
 fun NavGraphBuilder.loginScreen(
     onSignUpClick: () -> Unit,
-    onInputLoginClick: () -> Unit
+    onInputLoginClick: () -> Unit,
 ) {
     composable(route = loginRoute) {
         LoginRoute(
@@ -33,12 +33,14 @@ fun NavController.navigateToInputLogin(navOptions: NavOptions? = null) {
 fun NavGraphBuilder.inputLoginScreen(
     onBackClick: () -> Unit,
     onMainClick: () -> Unit,
+    onRePasswordClick: () -> Unit,
     onErrorToast: (throwable: Throwable?, message: String?) -> Unit
 ) {
     composable(route = InputLoginRoute) {
         InputLoginRoute(
             onBackClick = onBackClick,
             onMainClick = onMainClick,
+            onRePasswordClick = onRePasswordClick,
             onErrorToast = onErrorToast
         )
     }

--- a/feature/re-password/src/main/java/com/goms/re_password/EmailCheckScreen.kt
+++ b/feature/re-password/src/main/java/com/goms/re_password/EmailCheckScreen.kt
@@ -126,7 +126,7 @@ fun EmailCheckScreen(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             RePasswordText(modifier = Modifier.align(Alignment.Start))
-            Spacer(modifier = Modifier.weight(1.1f))
+            Spacer(modifier = Modifier.height(28.dp))
             GomsTextField(
                 modifier = Modifier.fillMaxWidth(),
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),

--- a/feature/re-password/src/main/java/com/goms/re_password/PasswordNumberScreen.kt
+++ b/feature/re-password/src/main/java/com/goms/re_password/PasswordNumberScreen.kt
@@ -47,6 +47,7 @@ import com.goms.re_password.viewmodel.VerifyNumberUiState
 fun PasswordNumberRoute(
     onBackClick: () -> Unit,
     onRePasswordClick: () -> Unit,
+    onErrorToast: (throwable: Throwable?, message: String?) -> Unit,
     viewModel: RePasswordViewmodel = hiltViewModel(LocalContext.current as ComponentActivity)
 ) {
     val verifyNumberUiState by viewModel.verifyNumberUiState.collectAsState()
@@ -58,6 +59,7 @@ fun PasswordNumberRoute(
         verifyNumberUiState = verifyNumberUiState,
         onBackClick = onBackClick,
         onRePasswordClick = onRePasswordClick,
+        onErrorToast = onErrorToast,
         numberCallback = {
             viewModel.verifyNumber(
                 email = "${viewModel.email.value}@gsm.hs.kr",
@@ -76,6 +78,7 @@ fun PasswordNumberScreen(
     verifyNumberUiState: VerifyNumberUiState,
     onBackClick: () -> Unit,
     onRePasswordClick: () -> Unit,
+    onErrorToast: (throwable: Throwable?, message: String?) -> Unit,
     numberCallback: () -> Unit,
     resentCallBack: () -> Unit,
     initCallBack: () -> Unit
@@ -101,17 +104,20 @@ fun PasswordNumberScreen(
                 isLoading = false
                 isError = true
                 errorText = "인증번호가 일치하지 않습니다"
+                onErrorToast(null, "인증번호가 일치하지 않습니다")
             }
 
             is VerifyNumberUiState.NotFound -> {
                 isLoading = false
                 isError = true
                 errorText = "잘못된 인증번호입니다"
+                onErrorToast(null, "잘못된 인증번호입니다")
             }
 
             is VerifyNumberUiState.Error -> {
                 isLoading = false
                 isError = true
+                onErrorToast(verifyNumberUiState.exception, null)
             }
         }
         onDispose { initCallBack() }
@@ -144,6 +150,7 @@ fun PasswordNumberScreen(
                 setText = number,
                 isError = isError,
                 errorText = errorText,
+                placeHolder = "인증번호 입력",
                 onValueChange = onNumberChange,
                 onResendClick = {
                     resentCallBack()

--- a/feature/re-password/src/main/java/com/goms/re_password/PasswordNumberScreen.kt
+++ b/feature/re-password/src/main/java/com/goms/re_password/PasswordNumberScreen.kt
@@ -30,13 +30,11 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.goms.common.result.Result
 import com.goms.design_system.component.button.ButtonState
 import com.goms.design_system.component.button.GomsBackButton
 import com.goms.design_system.component.button.GomsButton
 import com.goms.design_system.component.indicator.GomsCircularProgressIndicator
 import com.goms.design_system.component.textfield.NumberTextField
-import com.goms.design_system.theme.GomsTheme
 import com.goms.design_system.theme.GomsTheme.colors
 import com.goms.design_system.util.keyboardAsState
 import com.goms.design_system.util.lockScreenOrientation
@@ -46,7 +44,7 @@ import com.goms.re_password.viewmodel.RePasswordViewmodel
 import com.goms.re_password.viewmodel.VerifyNumberUiState
 
 @Composable
-fun NumberRoute(
+fun PasswordNumberRoute(
     onBackClick: () -> Unit,
     onRePasswordClick: () -> Unit,
     viewModel: RePasswordViewmodel = hiltViewModel(LocalContext.current as ComponentActivity)
@@ -54,7 +52,7 @@ fun NumberRoute(
     val verifyNumberUiState by viewModel.verifyNumberUiState.collectAsState()
     val number by viewModel.number.collectAsStateWithLifecycle()
 
-    NumberScreen(
+    PasswordNumberScreen(
         number = number,
         onNumberChange = viewModel::onNumberChange,
         verifyNumberUiState = verifyNumberUiState,
@@ -72,7 +70,7 @@ fun NumberRoute(
 }
 
 @Composable
-fun NumberScreen(
+fun PasswordNumberScreen(
     number: String,
     onNumberChange: (String) -> Unit,
     verifyNumberUiState: VerifyNumberUiState,
@@ -141,9 +139,9 @@ fun NumberScreen(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             NumberText(modifier = Modifier.align(Alignment.Start))
-            Spacer(modifier = Modifier.weight(2.1f))
+            Spacer(modifier = Modifier.height(28.dp))
             NumberTextField(
-                text = number,
+                setText = number,
                 isError = isError,
                 errorText = errorText,
                 onValueChange = onNumberChange,

--- a/feature/re-password/src/main/java/com/goms/re_password/RePasswordScreen.kt
+++ b/feature/re-password/src/main/java/com/goms/re_password/RePasswordScreen.kt
@@ -138,7 +138,7 @@ fun RePasswordScreen(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             RePasswordText(modifier = Modifier.align(Alignment.Start))
-            Spacer(modifier = Modifier.weight(1.1f))
+            Spacer(modifier = Modifier.height(28.dp))
             GomsPasswordTextField(
                 modifier = Modifier.fillMaxWidth(),
                 isError = isError,

--- a/feature/re-password/src/main/java/com/goms/re_password/RePasswordScreen.kt
+++ b/feature/re-password/src/main/java/com/goms/re_password/RePasswordScreen.kt
@@ -182,20 +182,21 @@ fun RePasswordScreen(
             }
             Spacer(modifier = Modifier.height(animatedSpacerHeight))
         }
-        if (isLoading) {
-            GomsCircularProgressIndicator()
-        }
-        if (openDialog) {
-            GomsOneButtonDialog(
-                openDialog = openDialog,
-                onStateChange = {
-                    openDialog = it
-                },
-                title = "재설정 완료",
-                content = "로그인 화면으로 돌아갑니다.",
-                buttonText = "확인",
-                onClick = onSuccessClick
-            )
-        }
+    }
+    if (isLoading) {
+        GomsCircularProgressIndicator()
+    }
+    if (openDialog) {
+        GomsOneButtonDialog(
+            openDialog = openDialog,
+            onStateChange = {
+                openDialog = it
+            },
+            title = "재설정 완료",
+            content = "비밀번호를 재설정했어요.\n" +
+                    "홈으로 돌아갈게요!",
+            buttonText = "확인",
+            onClick = onSuccessClick
+        )
     }
 }

--- a/feature/re-password/src/main/java/com/goms/re_password/navigation/RePasswordNavigation.kt
+++ b/feature/re-password/src/main/java/com/goms/re_password/navigation/RePasswordNavigation.kt
@@ -36,12 +36,14 @@ fun NavController.navigateToPasswordNumber(navOptions: NavOptions? = null) {
 
 fun NavGraphBuilder.passwordNumberScreen(
     onBackClick: () -> Unit,
-    onRePasswordClick: () -> Unit
+    onRePasswordClick: () -> Unit,
+    onErrorToast: (throwable: Throwable?, message: String?) -> Unit
 ) {
     composable(route = passwordNumberRoute) {
         PasswordNumberRoute(
             onBackClick = onBackClick,
-            onRePasswordClick = onRePasswordClick
+            onRePasswordClick = onRePasswordClick,
+            onErrorToast = onErrorToast
         )
     }
 }

--- a/feature/re-password/src/main/java/com/goms/re_password/navigation/RePasswordNavigation.kt
+++ b/feature/re-password/src/main/java/com/goms/re_password/navigation/RePasswordNavigation.kt
@@ -5,11 +5,11 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import com.goms.re_password.EmailCheckRoute
-import com.goms.re_password.NumberRoute
+import com.goms.re_password.PasswordNumberRoute
 import com.goms.re_password.RePasswordRoute
 
 const val emailCheckRoute = "email_check_route"
-const val numberRoute = "number_route"
+const val passwordNumberRoute = "password_number_route"
 const val rePasswordRoute = "re_password_route"
 
 fun NavController.navigateToEmailCheck(navOptions: NavOptions? = null) {
@@ -31,15 +31,15 @@ fun NavGraphBuilder.emailCheckScreen(
 }
 
 fun NavController.navigateToPasswordNumber(navOptions: NavOptions? = null) {
-    this.navigate(numberRoute, navOptions)
+    this.navigate(passwordNumberRoute, navOptions)
 }
 
 fun NavGraphBuilder.passwordNumberScreen(
     onBackClick: () -> Unit,
     onRePasswordClick: () -> Unit
 ) {
-    composable(route = numberRoute) {
-        NumberRoute(
+    composable(route = passwordNumberRoute) {
+        PasswordNumberRoute(
             onBackClick = onBackClick,
             onRePasswordClick = onRePasswordClick
         )

--- a/feature/sign-up/src/main/java/com/goms/sign_up/NumberScreen.kt
+++ b/feature/sign-up/src/main/java/com/goms/sign_up/NumberScreen.kt
@@ -146,10 +146,11 @@ fun NumberScreen(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             NumberText(modifier = Modifier.align(Alignment.Start))
-            Spacer(modifier = Modifier.weight(2.1f))
+            Spacer(modifier = Modifier.height(28.dp))
             NumberTextField(
-                text = number,
+                setText = number,
                 isError = isError,
+                placeHolder = "인증번호 입력",
                 errorText = errorText,
                 onValueChange = onNumberChange,
                 onResendClick = {

--- a/feature/sign-up/src/main/java/com/goms/sign_up/PasswordScreen.kt
+++ b/feature/sign-up/src/main/java/com/goms/sign_up/PasswordScreen.kt
@@ -148,7 +148,7 @@ fun PasswordScreen(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             PasswordText(modifier = Modifier.align(Alignment.Start))
-            Spacer(modifier = Modifier.weight(1.1f))
+            Spacer(modifier = Modifier.height(28.dp))
             GomsPasswordTextField(
                 modifier = Modifier.fillMaxWidth(),
                 isError = isError,

--- a/feature/sign-up/src/main/java/com/goms/sign_up/SignUpScreen.kt
+++ b/feature/sign-up/src/main/java/com/goms/sign_up/SignUpScreen.kt
@@ -139,7 +139,7 @@ fun SignUpScreen(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             SignUpText(modifier = Modifier.align(Alignment.Start))
-            Spacer(modifier = Modifier.weight(1.1f))
+            Spacer(modifier = Modifier.height(28.dp))
             GomsTextField(
                 modifier = Modifier.fillMaxWidth(),
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
@@ -149,6 +149,7 @@ fun SignUpScreen(
                 isEmail = false,
                 singleLine = true
             )
+            Spacer(modifier = Modifier.height(24.dp))
             GomsTextField(
                 modifier = Modifier.fillMaxWidth(),
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
@@ -157,12 +158,13 @@ fun SignUpScreen(
                 onValueChange = onEmailChange,
                 singleLine = true
             )
+            Spacer(modifier = Modifier.height(24.dp))
             SelectGenderDropDown(
                 onSelectGender = onGenderChange
             ) {
                 focusManager.clearFocus()
             }
-            Spacer(modifier = Modifier.height(30.dp))
+            Spacer(modifier = Modifier.height(24.dp))
             SelectMajorDropDown(
                 onSelectMajor = onMajorChange
             ) {

--- a/feature/sign-up/src/main/java/com/goms/sign_up/navigation/SignUpNavigation.kt
+++ b/feature/sign-up/src/main/java/com/goms/sign_up/navigation/SignUpNavigation.kt
@@ -1,6 +1,5 @@
 package com.goms.sign_up.navigation
 
-import androidx.lifecycle.ViewModelStoreOwner
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions


### PR DESCRIPTION
## 📌 개요
- 로그인, 회원가입, 비밀번호 재설정(찾기) 페이지 디자인 변경사항에 맞게 수정

## 🔀 변경사항
- 로그인 페이지 변경
- 회원가입 페이지 변경
- 비밀번호 재설정(찾기) 페이지 변경
- 몇 개의 컴포넌트 색상 변경
- 비밀번호 재설정에 헤더 제거

## 📸 구현 화면
[Screen_recording_20240322_153045.webm](https://github.com/team-haribo/GOMS-Android-V2/assets/103114398/b3f295a5-513b-45cd-93ae-ad2d021eee72)

[Screen_recording_20240322_153138.webm](https://github.com/team-haribo/GOMS-Android-V2/assets/103114398/07242032-7ad7-42ce-9fc2-00174221f335)

[Screen_recording_20240322_153239.webm](https://github.com/team-haribo/GOMS-Android-V2/assets/103114398/3d7b6167-51c6-489e-91fd-35fdec89063c)

