### PR TITLE
🔀 :: (#135) - fix navigation afterimage error

### DIFF
--- a/app/src/main/java/com/goms/goms_android_v2/navigation/GomsNavHost.kt
+++ b/app/src/main/java/com/goms/goms_android_v2/navigation/GomsNavHost.kt
@@ -1,5 +1,7 @@
 package com.goms.goms_android_v2.navigation
 
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -72,6 +74,10 @@ fun GomsNavHost(
     NavHost(
         navController = navController,
         startDestination = startDestination,
+        enterTransition = { EnterTransition.None },
+        exitTransition = { ExitTransition.None },
+        popEnterTransition = { EnterTransition.None },
+        popExitTransition = { ExitTransition.None },
         modifier = modifier
     ) {
         loginScreen(


### PR DESCRIPTION
## 📌 개요
화면전환간 잔상이 남는 버그 수정

## 🔀 변경사항
navHost에 Transition.none 추가

## 📸 구현 화면

https://github.com/team-haribo/GOMS-Android-V2/assets/108396442/66cf8a3a-cd9c-443b-a1d0-015a109bf805


