### PR TITLE
🔀 :: (#181) - fix wrong qrcode scan error

### DIFF
--- a/feature/qrcode/src/main/java/com/goms/qrcode/QrcodeScanScreen.kt
+++ b/feature/qrcode/src/main/java/com/goms/qrcode/QrcodeScanScreen.kt
@@ -56,8 +56,7 @@ fun QrcodeScanRoute(
             profileUiState = getProfileUiState,
             onQrcodeScan = { qrcodeData ->
                 try {
-                    val outingUUID = UUID.fromString(qrcodeData)
-                    viewModel.outing(outingUUID)
+                    viewModel.outing(UUID.fromString(qrcodeData))
                 } catch (e: IllegalArgumentException) {
                     viewModel.qrcodeDataError()
                 }

--- a/feature/qrcode/src/main/java/com/goms/qrcode/QrcodeScanScreen.kt
+++ b/feature/qrcode/src/main/java/com/goms/qrcode/QrcodeScanScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -56,7 +55,12 @@ fun QrcodeScanRoute(
             outingUiState = outingUiState,
             profileUiState = getProfileUiState,
             onQrcodeScan = { qrcodeData ->
-                viewModel.outing(UUID.fromString(qrcodeData))
+                try {
+                    val outingUUID = UUID.fromString(qrcodeData)
+                    viewModel.outing(outingUUID)
+                } catch (e: IllegalArgumentException) {
+                    viewModel.qrcodeDataError()
+                }
             },
             onSuccess = onSuccess,
             onBackClick = onBackClick,

--- a/feature/qrcode/src/main/java/com/goms/qrcode/viewmodel/QrcodeViewModel.kt
+++ b/feature/qrcode/src/main/java/com/goms/qrcode/viewmodel/QrcodeViewModel.kt
@@ -58,6 +58,10 @@ class QrcodeViewModel @Inject constructor(
             }
     }
 
+    fun qrcodeDataError() = viewModelScope.launch {
+        _outingState.value = OutingUiState.BadRequest
+    }
+
     fun getOutingUUID() = viewModelScope.launch {
         getOutingUUIDUseCase()
             .asResult()


### PR DESCRIPTION
## 📌 개요
- 잘못된 qrcode 스캔시 앱이 터지는 오류 수정

## 🔀 변경사항
- 인식한 qrcode data -> UUID 로 변환할때 IllegalArgumentException 발생시 OutingUiState 를 BadRequest로 변경하여 해결


