### PR TITLE
🔀 :: (#208) - apply password show hide

### DIFF
--- a/core/design-system/src/main/java/com/goms/design_system/component/textfield/GomsTextField.kt
+++ b/core/design-system/src/main/java/com/goms/design_system/component/textfield/GomsTextField.kt
@@ -3,18 +3,15 @@ package com.goms.design_system.component.textfield
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
@@ -22,9 +19,10 @@ import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusManager
@@ -37,12 +35,12 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.goms.design_system.component.clickable.gomsClickable
 import com.goms.design_system.component.timer.CountdownTimer
+import com.goms.design_system.icon.InvisibleIcon
 import com.goms.design_system.icon.SearchIcon
+import com.goms.design_system.icon.VisibleIcon
 import com.goms.design_system.theme.GomsTheme.colors
 import com.goms.design_system.theme.GomsTheme.typography
 import kotlinx.coroutines.delay
@@ -237,6 +235,7 @@ fun GomsPasswordTextField(
     onValueChange: (String) -> Unit = {},
 ) {
     val isFocused = remember { mutableStateOf(false) }
+    var passwordVisibility by remember { mutableStateOf(false) }
 
     DisposableEffect(Unit) {
         onDispose {
@@ -286,8 +285,13 @@ fun GomsPasswordTextField(
                 unfocusedBorderColor = Color.Transparent,
                 cursorColor = colors.I5
             ),
+            trailingIcon = {
+                IconButton(onClick = { passwordVisibility = !passwordVisibility }) {
+                    if (passwordVisibility) VisibleIcon(tint = colors.G7) else InvisibleIcon(tint = colors.G7)
+                }
+            },
             readOnly = readOnly,
-            visualTransformation = PasswordVisualTransformation()
+            visualTransformation = if (passwordVisibility) VisualTransformation.None else PasswordVisualTransformation()
         )
         Column(
             modifier = Modifier

--- a/core/design-system/src/main/java/com/goms/design_system/icon/GomsIcon.kt
+++ b/core/design-system/src/main/java/com/goms/design_system/icon/GomsIcon.kt
@@ -307,3 +307,29 @@ fun MenuIcon(
         colorFilter = if (tint != Color.Unspecified) ColorFilter.tint(tint) else null
     )
 }
+
+@Composable
+fun InvisibleIcon(
+    modifier: Modifier = Modifier,
+    tint: Color = Color.Unspecified
+) {
+    Image(
+        painter = painterResource(id = R.drawable.ic_invisible),
+        contentDescription = "Invisible Icon",
+        modifier = modifier,
+        colorFilter = if (tint != Color.Unspecified) ColorFilter.tint(tint) else null
+    )
+}
+
+@Composable
+fun VisibleIcon(
+    modifier: Modifier = Modifier,
+    tint: Color = Color.Unspecified
+) {
+    Image(
+        painter = painterResource(id = R.drawable.ic_visible),
+        contentDescription = "Visible Icon",
+        modifier = modifier,
+        colorFilter = if (tint != Color.Unspecified) ColorFilter.tint(tint) else null
+    )
+}

--- a/core/design-system/src/main/res/drawable/ic_invisible.xml
+++ b/core/design-system/src/main/res/drawable/ic_invisible.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M2,12C2,12 4.185,13.862 7,15.19M22,12C22,12 19.815,13.862 17,15.19M12,16.5V20M12,16.5C13.684,16.5 15.439,15.927 17,15.19M12,16.5C10.316,16.5 8.561,15.927 7,15.19M17,15.19L19,18M7,15.19L5,18"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#B3B3B3"
+      android:strokeLineCap="round"/>
+</vector>

--- a/core/design-system/src/main/res/drawable/ic_visible.xml
+++ b/core/design-system/src/main/res/drawable/ic_visible.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M2,12C2,12 4.185,10.138 7,8.81M22,12C22,12 19.815,10.138 17,8.81M12,7.5V4M12,7.5C13.684,7.5 15.439,8.073 17,8.81M12,7.5C10.316,7.5 8.561,8.073 7,8.81M17,8.81L19,6M7,8.81L5,6"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#B3B3B3"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M12,14m-4,0a4,4 0,1 1,8 0a4,4 0,1 1,-8 0"
+      android:fillColor="#B3B3B3"/>
+</vector>

--- a/feature/login/src/main/java/com/goms/login/InputLoginScreen.kt
+++ b/feature/login/src/main/java/com/goms/login/InputLoginScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -35,6 +34,7 @@ import com.goms.design_system.component.button.GomsBackButton
 import com.goms.design_system.component.button.GomsButton
 import com.goms.design_system.component.indicator.GomsCircularProgressIndicator
 import com.goms.design_system.component.text.RowLinkText
+import com.goms.design_system.component.textfield.GomsPasswordTextField
 import com.goms.design_system.component.textfield.GomsTextField
 import com.goms.design_system.theme.GomsTheme.colors
 import com.goms.design_system.util.keyboardAsState
@@ -182,16 +182,15 @@ fun InputLoginScreen(
                 singleLine = true
             )
             Spacer(modifier = Modifier.height(24.dp))
-            GomsTextField(
+            GomsPasswordTextField(
                 modifier = Modifier.fillMaxWidth(),
-                isEmail = false,
+                isError = isError,
+                isDescription = false,
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
                 placeHolder = "비밀번호",
                 setText = password,
                 onValueChange = onPasswordChange,
-                isError = isError,
-                singleLine = true,
-                visualTransformation = PasswordVisualTransformation()
+                singleLine = true
             )
             Spacer(modifier = Modifier.height(8.dp))
             RowLinkText {


### PR DESCRIPTION
## 📌 개요
- 비밀번호 표시/숨기기 적용

## 🔀 변경사항
- 비밀번호 텍스트 필드에 아이콘 추가
- 비밀번호 텍스트 표시/숨기기 기능 추가

## 📸 구현 화면
[Screen_recording_20240509_145634.webm](https://github.com/team-haribo/GOMS-Android-V2/assets/103114398/14b3b632-052c-4d66-87ce-d13de1f012fd)
