### PR TITLE
 🔀 ::  (#214) - main page outgoing status limitations on number of people

### DIFF
--- a/feature/main/src/main/java/com/goms/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/goms/main/MainScreen.kt
@@ -235,7 +235,7 @@ fun MainScreen(
                         onLateListClick()
                     }
                 }
-                Column(modifier = Modifier.padding(top = 32.dp,start = 16.dp, end = 16.dp)) {
+                Column(modifier = Modifier.padding(top = 32.dp, start = 16.dp, end = 16.dp)) {
                     MainOutingCard(
                         role = role,
                         getOutingListUiState = getOutingListUiState,

--- a/feature/main/src/main/java/com/goms/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/goms/main/MainScreen.kt
@@ -235,8 +235,7 @@ fun MainScreen(
                         onLateListClick()
                     }
                 }
-                Spacer(modifier = Modifier.height(32.dp))
-                Column(modifier = Modifier.padding(horizontal = 16.dp)) {
+                Column(modifier = Modifier.padding(top = 32.dp,start = 16.dp, end = 16.dp)) {
                     MainOutingCard(
                         role = role,
                         getOutingListUiState = getOutingListUiState,

--- a/feature/main/src/main/java/com/goms/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/goms/main/MainScreen.kt
@@ -9,7 +9,9 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
@@ -209,7 +211,6 @@ fun MainScreen(
                 )
                 Column(
                     modifier = Modifier
-                        .fillMaxSize()
                         .verticalScroll(scrollState)
                         .padding(horizontal = 16.dp),
                     verticalArrangement = Arrangement.spacedBy(32.dp)
@@ -233,6 +234,9 @@ fun MainScreen(
                     ) {
                         onLateListClick()
                     }
+                }
+                Spacer(modifier = Modifier.height(32.dp))
+                Column(modifier = Modifier.padding(horizontal = 16.dp)) {
                     MainOutingCard(
                         role = role,
                         getOutingListUiState = getOutingListUiState,


### PR DESCRIPTION
## 📌 개요
- 메인페이지 외출현황 인원수 제한(스크롤 범위 수정)

## 🔀 변경사항
- 스크롤 범위 수정

## 📸 구현 화면
- 
[Screen_recording_20240516_102501.webm](https://github.com/team-haribo/GOMS-Android-V2/assets/108396442/2c4517c0-ecfd-45f7-b387-93b4d72b6a5d)
