### PR TITLE
🔀 :: (#245) - handling error during duplicate refresh call

### DIFF
--- a/feature/main/src/main/java/com/goms/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/goms/main/MainScreen.kt
@@ -41,6 +41,7 @@ import com.goms.main.component.MainOutingCard
 import com.goms.main.component.MainProfileCard
 import com.goms.main.component.MainTimeProfileCard
 import com.goms.main.viewmodel.MainViewModel
+import com.goms.main.viewmodel.uistate.SaveTokenUiState
 import com.goms.main.viewmodel.uistate.TokenRefreshUiState
 import com.goms.model.enum.Switch
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
@@ -67,6 +68,7 @@ internal fun MainRoute(
     val timeValue by viewModel.timeValue.collectAsStateWithLifecycle(initialValue = Switch.OFF.value)
     val isRefreshing by viewModel.isRefreshing.collectAsStateWithLifecycle()
     val tokenRefreshUiState by viewModel.tokenRefreshUiState.collectAsStateWithLifecycle()
+    val saveTokenUiState by viewModel.saveTokenUiState.collectAsStateWithLifecycle()
     val getProfileUiState by viewModel.getProfileUiState.collectAsStateWithLifecycle()
     val getLateRankListUiState by viewModel.getLateRankListUiState.collectAsStateWithLifecycle()
     val getOutingListUiState by viewModel.getOutingListUiState.collectAsStateWithLifecycle()
@@ -89,6 +91,7 @@ internal fun MainRoute(
         isRefreshing = isRefreshing,
         isTimeLaunch = isTimeLaunch,
         tokenRefreshUiState = tokenRefreshUiState,
+        saveTokenUiState = saveTokenUiState,
         getProfileUiState = getProfileUiState,
         getLateRankListUiState = getLateRankListUiState,
         getOutingListUiState = getOutingListUiState,
@@ -108,6 +111,9 @@ internal fun MainRoute(
         },
         tokenRefreshCallBack = {
             viewModel.tokenRefresh()
+        },
+        initTokenRefreshCallBack = {
+            viewModel.initTokenRefresh()
         }
     )
 }
@@ -119,6 +125,7 @@ private fun MainScreen(
     isRefreshing: Boolean,
     isTimeLaunch: Boolean,
     tokenRefreshUiState: TokenRefreshUiState,
+    saveTokenUiState: SaveTokenUiState,
     getProfileUiState: GetProfileUiState,
     getLateRankListUiState: GetLateRankListUiState,
     getOutingListUiState: GetOutingListUiState,
@@ -131,7 +138,8 @@ private fun MainScreen(
     onAdminMenuClick: () -> Unit,
     onErrorToast: (throwable: Throwable?, message: Int?) -> Unit,
     mainCallBack: () -> Unit,
-    tokenRefreshCallBack: () -> Unit
+    tokenRefreshCallBack: () -> Unit,
+    initTokenRefreshCallBack: () -> Unit
 ) {
     var isPermissionRequest by rememberSaveable { mutableStateOf(false) }
     val multiplePermissionState = rememberMultiplePermissionsState(
@@ -163,7 +171,7 @@ private fun MainScreen(
         if (tokenRefreshUiState is TokenRefreshUiState.Error) {
             onErrorToast(null, R.string.error_refresh)
         }
-        onDispose {}
+        onDispose { initTokenRefreshCallBack() }
     }
 
     val scrollState = rememberScrollState()


### PR DESCRIPTION
## 📌 개요
- 새로고침 중복 호출시 에러 처리

## 🔀 변경사항
- 같은 시간(초까지)에 토큰 재발급 요청을 보낼 시 같은 토큰이 응답으로 와서 토큰 리프래시 과정에서 1초 딜레이 적용
- 새로고침 uistate 초기화 기능 추가

## 📸 구현 화면
[Screen_recording_20240612_014511.webm](https://github.com/team-haribo/GOMS-Android-V2/assets/103114398/85f8e3fc-100e-4995-8e3c-ee8d07591b06)

