### PR TITLE
🔀 :: (#242) - setting screen modify

### DIFF
--- a/feature/setting/src/main/java/com/goms/setting/SettingScreen.kt
+++ b/feature/setting/src/main/java/com/goms/setting/SettingScreen.kt
@@ -14,6 +14,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Divider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -195,7 +197,9 @@ private fun SettingScreen(
     var openDialog by remember { mutableStateOf(false) }
     var openBottomSheet by remember { mutableStateOf(false) }
     var isLogout by remember { mutableStateOf(true) }
+
     val notificationPermissionState = rememberPermissionState(Manifest.permission.POST_NOTIFICATIONS)
+    val scrollState = rememberScrollState()
 
     LaunchedEffect("load data") {
         getProfile()
@@ -253,7 +257,9 @@ private fun SettingScreen(
             onBackClick()
         }
         Column(
-            modifier = Modifier.padding(horizontal = 20.dp),
+            modifier = Modifier
+                .padding(horizontal = 20.dp)
+                .verticalScroll(scrollState),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Spacer(modifier = Modifier.height(16.dp))

--- a/feature/setting/src/main/java/com/goms/setting/component/SettingButton.kt
+++ b/feature/setting/src/main/java/com/goms/setting/component/SettingButton.kt
@@ -57,9 +57,9 @@ internal fun SettingButton(
         ) {
             Row {
                 when(buttonType) {
-                    SettingButtonType.PasswordChange.value -> GomsPasswordChangeIcon()
-                    SettingButtonType.Logout.value -> GomsLogoutIcon()
-                    SettingButtonType.Withdrawal.value -> GomsWithdrawalIcon()
+                    SettingButtonType.PasswordChange.value -> GomsPasswordChangeIcon(tint = colors.WHITE)
+                    SettingButtonType.Logout.value -> GomsLogoutIcon(tint = colors.WHITE)
+                    SettingButtonType.Withdrawal.value -> GomsWithdrawalIcon(tint = colors.WHITE)
                     else -> GomsPasswordChangeIcon()
                 }
                 Spacer(modifier = Modifier.width(8.dp))

--- a/feature/setting/src/main/java/com/goms/setting/component/SettingButton.kt
+++ b/feature/setting/src/main/java/com/goms/setting/component/SettingButton.kt
@@ -60,7 +60,6 @@ internal fun SettingButton(
                     SettingButtonType.PasswordChange.value -> GomsPasswordChangeIcon(tint = colors.WHITE)
                     SettingButtonType.Logout.value -> GomsLogoutIcon(tint = colors.WHITE)
                     SettingButtonType.Withdrawal.value -> GomsWithdrawalIcon(tint = colors.WHITE)
-                    else -> GomsPasswordChangeIcon()
                 }
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(


### PR DESCRIPTION
## 📌 개요
- 화면비가 작은 핸드폰은 회원탈퇴 버튼이 보이지 않는 사항 수정
- 라이트 모드 설정시 SettingButton의 아이콘이 보이지 않는 사항 수정

## 🔀 변경사항
- SettingScreen Scroll 추가
- Setting icon tint 추가

## 📸 구현 화면
- 

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- 참고할 사항이 있다면 적어주세요.
