### PR TITLE
🔀 :: (#275) - cancel when the filter option is active if pressed again

### DIFF
--- a/core/design-system/src/main/java/com/goms/design_system/component/bottomsheet/MultipleSelectorBottomSheet.kt
+++ b/core/design-system/src/main/java/com/goms/design_system/component/bottomsheet/MultipleSelectorBottomSheet.kt
@@ -143,7 +143,11 @@ fun MultipleSelectorBottomSheetItem(
                 text = list[it],
                 selected = selectedItem == list[it]
             ) {
-                itemChange(list[it])
+                if (selectedItem == list[it]) {
+                    itemChange("")
+                } else {
+                    itemChange(list[it])
+                }
             }
         }
     }


### PR DESCRIPTION
## 📌 개요
- 필터 옵션 활성화 상태일때 다시 누르면 취소

## 🔀 변경사항
- 현재 필터가 활성화되어있을때 다시 누르면 취소되게 변경

## 📸 구현 화면
[Screen_recording_20240627_201748.webm](https://github.com/team-haribo/GOMS-Android-V2/assets/103114398/89cf4d4e-8fcc-4a09-8f12-0a70befc1a80)
