### PR TITLE
🔀 :: (#288) - customizing a screen change animation

### DIFF
--- a/app/src/main/java/com/goms/goms_android_v2/navigation/GomsNavHost.kt
+++ b/app/src/main/java/com/goms/goms_android_v2/navigation/GomsNavHost.kt
@@ -1,7 +1,9 @@
 package com.goms.goms_android_v2.navigation
 
+import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.core.tween
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -26,6 +28,7 @@ import com.goms.login.navigation.loginScreen
 import com.goms.login.navigation.navigateToInputLogin
 import com.goms.main.navigation.adminMenuScreen
 import com.goms.main.navigation.lateListScreen
+import com.goms.main.navigation.mainRoute
 import com.goms.main.navigation.mainScreen
 import com.goms.main.navigation.navigateToAdminMenu
 import com.goms.main.navigation.navigateToLateList
@@ -45,7 +48,6 @@ import com.goms.re_password.navigation.rePasswordScreen
 import com.goms.setting.navigation.navigateToSettingScreen
 import com.goms.setting.navigation.navigateToWithdrawalScreen
 import com.goms.setting.navigation.settingScreen
-import com.goms.setting.navigation.withdrawalRoute
 import com.goms.setting.navigation.withdrawalScreen
 import com.goms.sign_up.navigation.navigateToNumber
 import com.goms.sign_up.navigation.navigateToPassword
@@ -87,10 +89,38 @@ fun GomsNavHost(
     NavHost(
         navController = navController,
         startDestination = startDestination,
-        enterTransition = { EnterTransition.None },
-        exitTransition = { ExitTransition.None },
-        popEnterTransition = { EnterTransition.None },
-        popExitTransition = { ExitTransition.None },
+        enterTransition = {
+            if (targetState.destination.route != mainRoute) {
+                slideIntoContainer(
+                    AnimatedContentTransitionScope.SlideDirection.Left,
+                    animationSpec = tween(700)
+                )
+            } else {
+                EnterTransition.None
+            }
+        },
+        exitTransition = {
+            if (targetState.destination.route != mainRoute) {
+                slideOutOfContainer(
+                    AnimatedContentTransitionScope.SlideDirection.Left,
+                    animationSpec = tween(700)
+                )
+            } else {
+                ExitTransition.None
+            }
+        },
+        popEnterTransition = {
+            slideIntoContainer(
+                AnimatedContentTransitionScope.SlideDirection.Right,
+                animationSpec = tween(700)
+            )
+        },
+        popExitTransition = {
+            slideOutOfContainer(
+                AnimatedContentTransitionScope.SlideDirection.Right,
+                animationSpec = tween(700)
+            )
+        },
         modifier = modifier
     ) {
         loginScreen(

--- a/app/src/main/java/com/goms/goms_android_v2/navigation/GomsNavHost.kt
+++ b/app/src/main/java/com/goms/goms_android_v2/navigation/GomsNavHost.kt
@@ -93,7 +93,7 @@ fun GomsNavHost(
             if (targetState.destination.route != mainRoute) {
                 slideIntoContainer(
                     AnimatedContentTransitionScope.SlideDirection.Left,
-                    animationSpec = tween(700)
+                    animationSpec = tween(500)
                 )
             } else {
                 EnterTransition.None
@@ -103,7 +103,7 @@ fun GomsNavHost(
             if (targetState.destination.route != mainRoute) {
                 slideOutOfContainer(
                     AnimatedContentTransitionScope.SlideDirection.Left,
-                    animationSpec = tween(700)
+                    animationSpec = tween(500)
                 )
             } else {
                 ExitTransition.None
@@ -112,13 +112,13 @@ fun GomsNavHost(
         popEnterTransition = {
             slideIntoContainer(
                 AnimatedContentTransitionScope.SlideDirection.Right,
-                animationSpec = tween(700)
+                animationSpec = tween(500)
             )
         },
         popExitTransition = {
             slideOutOfContainer(
                 AnimatedContentTransitionScope.SlideDirection.Right,
-                animationSpec = tween(700)
+                animationSpec = tween(500)
             )
         },
         modifier = modifier


### PR DESCRIPTION
## 📌 개요
- 화면전환 애니메이션 커스텀 하기

## 🔀 변경사항
- 메인 화면 진입을 제외한 화면 이동시에 슬라이드 애니메이션 추가

## 📸 구현 화면
[Screen_recording_20240709_094200.webm](https://github.com/team-haribo/GOMS-Android-V2/assets/103114398/aaa62406-ebf9-4efd-8ef9-a6a2a8d2873e)

