### PR TITLE
🔀 :: (#293) - separate email authentication number request logic

### DIFF
--- a/core/model/src/main/java/com/goms/model/enum/EmailStatus.kt
+++ b/core/model/src/main/java/com/goms/model/enum/EmailStatus.kt
@@ -1,0 +1,6 @@
+package com.goms.model.enum
+
+enum class EmailStatus {
+    BEFORE_SIGNUP,
+    AFTER_SIGNUP
+}

--- a/core/model/src/main/java/com/goms/model/request/auth/SendNumberRequestModel.kt
+++ b/core/model/src/main/java/com/goms/model/request/auth/SendNumberRequestModel.kt
@@ -1,5 +1,8 @@
 package com.goms.model.request.auth
 
+import com.goms.model.enum.EmailStatus
+
 data class SendNumberRequestModel(
-    val email: String
+    val email: String,
+    val emailStatus: EmailStatus
 )

--- a/core/network/src/main/java/com/goms/network/dto/request/auth/SendNumberRequest.kt
+++ b/core/network/src/main/java/com/goms/network/dto/request/auth/SendNumberRequest.kt
@@ -1,9 +1,11 @@
 package com.goms.network.dto.request.auth
 
+import com.goms.model.enum.EmailStatus
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
 data class SendNumberRequest(
-    @Json(name = "email") val email: String
+    @Json(name = "email") val email: String,
+    @Json(name = "emailStatus") val emailStatus: EmailStatus,
 )

--- a/core/network/src/main/java/com/goms/network/mapper/request/auth/SendNumverRequestMapper.kt
+++ b/core/network/src/main/java/com/goms/network/mapper/request/auth/SendNumverRequestMapper.kt
@@ -4,4 +4,7 @@ import com.goms.model.request.auth.SendNumberRequestModel
 import com.goms.network.dto.request.auth.SendNumberRequest
 
 fun SendNumberRequestModel.toDto(): SendNumberRequest =
-    SendNumberRequest(email = this.email)
+    SendNumberRequest(
+        email = this.email,
+        emailStatus = this.emailStatus
+    )

--- a/feature/find-password/src/main/java/com/goms/find_password/EmailCheckScreen.kt
+++ b/feature/find-password/src/main/java/com/goms/find_password/EmailCheckScreen.kt
@@ -51,6 +51,7 @@ import com.goms.find_password.component.FindPasswordText
 import com.goms.model.request.auth.SendNumberRequestModel
 import com.goms.find_password.viewmodel.FindPasswordViewmodel
 import com.goms.find_password.viewmodel.uistate.SendNumberUiState
+import com.goms.model.enum.EmailStatus
 import com.goms.model.util.ResourceKeys
 
 @Composable
@@ -70,7 +71,10 @@ internal fun EmailCheckRoute(
         sendNumberUiState = sendNumberUiState,
         emailCheckCallBack = {
             viewModel.sendNumber(
-                body = SendNumberRequestModel("${viewModel.email.value}${ResourceKeys.EMAIL_DOMAIN}")
+                body = SendNumberRequestModel(
+                    email = "${viewModel.email.value}${ResourceKeys.EMAIL_DOMAIN}",
+                    emailStatus = EmailStatus.AFTER_SIGNUP
+                )
             )
         },
         onNumberClick = onNumberClick,
@@ -108,6 +112,11 @@ private fun EmailCheckScreen(
             is SendNumberUiState.EmailNotValid -> {
                 isLoading = false
                 onErrorToast(null, R.string.error_email_not_valid)
+            }
+
+            is SendNumberUiState.NotFound -> {
+                isLoading = false
+                onErrorToast(null, R.string.error_not_found_send_email)
             }
 
             is SendNumberUiState.TooManyRequest -> {

--- a/feature/find-password/src/main/java/com/goms/find_password/PasswordNumberScreen.kt
+++ b/feature/find-password/src/main/java/com/goms/find_password/PasswordNumberScreen.kt
@@ -52,6 +52,7 @@ import com.goms.find_password.viewmodel.FindPasswordViewmodel
 import com.goms.find_password.viewmodel.uistate.FindPasswordUiState
 import com.goms.find_password.viewmodel.uistate.SendNumberUiState
 import com.goms.find_password.viewmodel.uistate.VerifyNumberUiState
+import com.goms.model.enum.EmailStatus
 import com.goms.model.util.ResourceKeys
 
 @Composable
@@ -77,7 +78,14 @@ internal fun PasswordNumberRoute(
                 authCode = viewModel.number.value
             )
         },
-        resentCallBack = { viewModel.sendNumber(body = SendNumberRequestModel("${viewModel.email.value}${ResourceKeys.EMAIL_DOMAIN}")) },
+        resentCallBack = {
+            viewModel.sendNumber(
+                body = SendNumberRequestModel(
+                    email = "${viewModel.email.value}${ResourceKeys.EMAIL_DOMAIN}",
+                    emailStatus = EmailStatus.AFTER_SIGNUP
+                )
+            )
+        },
         initCallBack = viewModel::initVerifyNumber
     )
 }

--- a/feature/find-password/src/main/java/com/goms/find_password/viewmodel/FindPasswordViewmodel.kt
+++ b/feature/find-password/src/main/java/com/goms/find_password/viewmodel/FindPasswordViewmodel.kt
@@ -91,6 +91,7 @@ class FindPasswordViewmodel @Inject constructor(
                     it.catch { remoteError ->
                         _sendNumberUiState.value = SendNumberUiState.Error(remoteError)
                         remoteError.errorHandling(
+                            notFoundAction = { _sendNumberUiState.value = SendNumberUiState.NotFound },
                             tooManyRequestAction = { _sendNumberUiState.value = SendNumberUiState.TooManyRequest }
                         )
                     }.collect { result ->
@@ -99,6 +100,7 @@ class FindPasswordViewmodel @Inject constructor(
                 }.onFailure {
                     _sendNumberUiState.value = SendNumberUiState.Error(it)
                     it.errorHandling(
+                        notFoundAction = { _sendNumberUiState.value = SendNumberUiState.NotFound },
                         tooManyRequestAction = { _sendNumberUiState.value = SendNumberUiState.TooManyRequest }
                     )
                 }

--- a/feature/find-password/src/main/java/com/goms/find_password/viewmodel/uistate/SendNumberUiState.kt
+++ b/feature/find-password/src/main/java/com/goms/find_password/viewmodel/uistate/SendNumberUiState.kt
@@ -4,6 +4,7 @@ sealed interface SendNumberUiState {
     object Loading : SendNumberUiState
     object Success : SendNumberUiState
     object EmailNotValid : SendNumberUiState
+    object NotFound : SendNumberUiState
     object TooManyRequest : SendNumberUiState
     data class Error(val exception: Throwable) : SendNumberUiState
 }

--- a/feature/find-password/src/main/res/values/strings.xml
+++ b/feature/find-password/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="reset_password">비밀번호 재설정</string>
 
     <string name="error_email_not_valid">이메일 형식이 올바르지 않습니다</string>
+    <string name="error_not_found_send_email">존재하지 않는 이메일입니다.</string>
     <string name="error_too_many_request_send_email">인증번호 요청이 5번을 초과했습니다, 5분후에 재시도해주세요</string>
     <string name="error_send_number">인증번호 전송이 실패했습니다</string>
     <string name="email">이메일</string>

--- a/feature/sign-up/src/main/java/com/goms/sign_up/NumberScreen.kt
+++ b/feature/sign-up/src/main/java/com/goms/sign_up/NumberScreen.kt
@@ -46,6 +46,7 @@ import com.goms.design_system.theme.GomsTheme.colors
 import com.goms.design_system.theme.ThemeType
 import com.goms.design_system.util.keyboardAsState
 import com.goms.design_system.util.lockScreenOrientation
+import com.goms.model.enum.EmailStatus
 import com.goms.model.request.auth.SendNumberRequestModel
 import com.goms.model.util.ResourceKeys
 import com.goms.sign_up.component.NumberText
@@ -75,7 +76,14 @@ internal fun NumberRoute(
             )
         },
         onErrorToast = onErrorToast,
-        resentCallBack = { viewModel.sendNumber(body = SendNumberRequestModel("${viewModel.email.value}${ResourceKeys.EMAIL_DOMAIN}")) },
+        resentCallBack = {
+            viewModel.sendNumber(
+                body = SendNumberRequestModel(
+                    email = "${viewModel.email.value}${ResourceKeys.EMAIL_DOMAIN}",
+                    emailStatus = EmailStatus.BEFORE_SIGNUP
+                )
+            )
+        },
         initCallBack = viewModel::initVerifyNumber
     )
 }

--- a/feature/sign-up/src/main/java/com/goms/sign_up/SignUpScreen.kt
+++ b/feature/sign-up/src/main/java/com/goms/sign_up/SignUpScreen.kt
@@ -45,6 +45,7 @@ import com.goms.design_system.theme.GomsTheme.colors
 import com.goms.design_system.theme.ThemeType
 import com.goms.design_system.util.keyboardAsState
 import com.goms.design_system.util.lockScreenOrientation
+import com.goms.model.enum.EmailStatus
 import com.goms.model.request.auth.SendNumberRequestModel
 import com.goms.model.util.ResourceKeys
 import com.goms.sign_up.component.SelectGenderDropDown
@@ -79,7 +80,14 @@ internal fun SignUpRoute(
         onBackClick = onBackClick,
         onNumberClick = onNumberClick,
         onErrorToast = onErrorToast,
-        signUpCallBack = { viewModel.sendNumber(body = SendNumberRequestModel("${viewModel.email.value}${ResourceKeys.EMAIL_DOMAIN}")) },
+        signUpCallBack = {
+            viewModel.sendNumber(
+                body = SendNumberRequestModel(
+                    email = "${viewModel.email.value}${ResourceKeys.EMAIL_DOMAIN}",
+                    emailStatus = EmailStatus.BEFORE_SIGNUP
+                )
+            )
+        },
         initCallBack = viewModel::initSendNumber
     )
 }


### PR DESCRIPTION
## 📌 개요
- 이메일 인증번호 요청 로직 분리하기

## 🔀 변경사항
- 이메일 인증번호 요청 로직을 회원가입 전과 후로 나눠서 처리하도록 변경

## 📸 구현 화면
[Screen_recording_20240712_101252.webm](https://github.com/user-attachments/assets/95565074-1b44-4caa-bf9a-eac628d275ba)

