### PR TITLE
🔀 :: (#298) - save device token as datastore

### DIFF
--- a/app/src/main/java/com/goms/goms_android_v2/GomsNotification.kt
+++ b/app/src/main/java/com/goms/goms_android_v2/GomsNotification.kt
@@ -9,10 +9,20 @@ import androidx.core.app.NotificationCompat
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import com.goms.design_system.R
-import com.goms.model.util.ResourceKeys
+import com.goms.domain.notification.SaveDeviceTokenUseCase
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import javax.inject.Inject
 
+@AndroidEntryPoint
 class GomsNotification : FirebaseMessagingService() {
-    companion object {
+
+    @Inject
+    lateinit var saveDeviceTokenUseCase: SaveDeviceTokenUseCase
+
+    private companion object {
         private const val CHANNEL_NAME = "GOMS"
         private const val CHANNEL_DESCRIPTION = "GOMS NOTIFICATION"
         private const val CHANNEL_ID = "goms_channel_id"
@@ -22,12 +32,16 @@ class GomsNotification : FirebaseMessagingService() {
     override fun onMessageReceived(message: RemoteMessage) {
         super.onMessageReceived(message)
         createNotificationChannel()
-        message.notification?.let { sendNotification(it.title, it.body) }
+        val title = message.data["title"].orEmpty()
+        val body = message.data["body"].orEmpty()
+        sendNotification(title, body)
     }
 
     override fun onNewToken(token: String) {
         super.onNewToken(token)
-        saveDeviceToken(token)
+        CoroutineScope(Dispatchers.IO).launch {
+            saveDeviceTokenUseCase(token)
+        }
     }
 
     private fun createNotificationChannel() {
@@ -63,10 +77,5 @@ class GomsNotification : FirebaseMessagingService() {
 
         val notificationManager = getSystemService(NotificationManager::class.java)
         notificationManager?.notify(messageId, notificationBuilder.build())
-    }
-
-    private fun saveDeviceToken(token: String) {
-        val deviceTokenSF = getSharedPreferences(ResourceKeys.DEVICE_TOKEN, MODE_PRIVATE)
-        deviceTokenSF.edit().putString(ResourceKeys.DEVICE, token).apply()
     }
 }

--- a/app/src/main/java/com/goms/goms_android_v2/MainActivity.kt
+++ b/app/src/main/java/com/goms/goms_android_v2/MainActivity.kt
@@ -13,9 +13,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.lifecycleScope
-import com.goms.common.result.Result
 import com.goms.goms_android_v2.ui.GomsApp
-import com.goms.model.util.ResourceKeys
 import com.goms.ui.createToast
 import com.google.android.play.core.appupdate.AppUpdateManagerFactory
 import com.google.android.play.core.install.model.AppUpdateType
@@ -67,7 +65,7 @@ class MainActivity : ComponentActivity() {
                     windowSizeClass = calculateWindowSizeClass(this),
                     onLogout = { logout() },
                     onAlarmOff = { viewModel.deleteDeviceToken() },
-                    onAlarmOn = { getNotification() },
+                    onAlarmOn = { saveNotification() },
                     uiState = uiState,
                 )
             }
@@ -104,30 +102,11 @@ class MainActivity : ComponentActivity() {
         }
     }
 
-    private fun getNotification() {
+    private fun saveNotification() {
         FirebaseMessaging.getInstance().token.addOnCompleteListener { task ->
             if (task.isSuccessful) {
-                val deviceTokenSF = getSharedPreferences(ResourceKeys.DEVICE_TOKEN, MODE_PRIVATE)
                 val deviceToken = task.result
-                if (deviceTokenSF.getString(ResourceKeys.DEVICE, ResourceKeys.EMPTY) == deviceToken) {
-                    viewModel.saveDeviceToken(deviceToken = deviceToken)
-                    setNotification(deviceToken = deviceToken)
-                }
-            }
-        }
-    }
-
-    private fun setNotification(deviceToken: String) {
-        lifecycleScope.launch {
-            viewModel.saveDeviceTokenUiState.collect {
-                when (it) {
-                    is Result.Success -> {
-                        val deviceTokenSF = getSharedPreferences(ResourceKeys.DEVICE_TOKEN, MODE_PRIVATE)
-                        deviceTokenSF.edit().putString(ResourceKeys.DEVICE, deviceToken).apply()
-                    }
-
-                    is Result.Error, Result.Loading -> Unit
-                }
+                viewModel.saveDeviceToken(deviceToken = deviceToken)
             }
         }
     }

--- a/app/src/main/java/com/goms/goms_android_v2/MainActivityViewModel.kt
+++ b/app/src/main/java/com/goms/goms_android_v2/MainActivityViewModel.kt
@@ -66,6 +66,9 @@ class MainActivityViewModel @Inject constructor(
     private val _saveDeviceTokenUiState = MutableStateFlow<Result<Unit>>(Result.Loading)
     val saveDeviceTokenUiState = _saveDeviceTokenUiState.asStateFlow()
 
+    private val _deleteDeviceTokenUiState = MutableStateFlow<Result<Unit>>(Result.Loading)
+    val deleteDeviceTokenUiState = _deleteDeviceTokenUiState.asStateFlow()
+
     private val _themeState = MutableStateFlow(ResourceKeys.EMPTY)
     val themeState = _themeState.asStateFlow()
 
@@ -90,6 +93,15 @@ class MainActivityViewModel @Inject constructor(
 
     fun deleteDeviceToken() = viewModelScope.launch {
         deleteDeviceTokenUseCase()
+            .onSuccess {
+                it.catch { remoteError ->
+                    _deleteDeviceTokenUiState.value = Result.Error(remoteError)
+                }.collect { result ->
+                    _deleteDeviceTokenUiState.value = Result.Success(result)
+                }
+            }.onFailure {
+                _deleteDeviceTokenUiState.value = Result.Error(it)
+            }
     }
 
     fun deleteToken() = viewModelScope.launch {


### PR DESCRIPTION
## 📌 개요
- 디바이스 토큰 로직 변경

## 🔀 변경사항
- 디바이스 토큰을 로컬에 저장하지 않고 새로운 토큰이 발행시 바로 서버로 전달하도록 변경
