### PR TITLE
🔀(342):: andridmainfest  수정

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,9 +6,6 @@
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
-    <uses-permission
-        android:name="android.permission.READ_EXTERNAL_STORAGE"
-        android:maxSdkVersion="32" />
 
     <uses-feature android:name="android.hardware.camera" />
 


### PR DESCRIPTION
## 📌 개요
 안드로이드 13(API 33) 이상에서는 READ_EXTERNAL_STORAGE 대신 READ_MEDIA_IMAGES 및 READ_MEDIA_VIDEO를 사용해야 합니다. 따라서 READ_EXTRNAL_STORAGE 를 삭제하였습니다.

## 🔀 변경사항
-READ_EXTRNAL_STORAGE 를 삭제하였습니다.

## 📸 구현 화면
- 스크린샷이 필요하다면 첨부해주세요.

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- 참고할 사항이 있다면 적어주세요.
