### PR TITLE
🔀 :: (#376) - CD 수정

### DIFF
--- a/.github/workflows/goms_android_cd.yml
+++ b/.github/workflows/goms_android_cd.yml
@@ -27,9 +27,9 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', '**/buildSrc/**/*.kt') }}
+          key: ${{ runner.os }}-gradle-v2-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', '**/buildSrc/**/*.kt') }}
           restore-keys: |
-            ${{ runner.os }}-gradle-
+            ${{ runner.os }}-gradle-v2-
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew


### PR DESCRIPTION
## 📌 개요
- CD수정을 했는데도 SDK가 27로 나와서 캐시 키에 버전 추가하여 이전 캐시 무효화하였습니다.

## 🔀 변경사항
- goms__android_cd.yml

## 📸 구현 화면
- 스크린샷이 필요하다면 첨부해주세요.

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- 참고할 사항이 있다면 적어주세요.
